### PR TITLE
[FIX] timeblock 및 calendar 반영 지연문제 해결 + UX개선

### DIFF
--- a/src/apis/tasks/updateTaskStatus/query.ts
+++ b/src/apis/tasks/updateTaskStatus/query.ts
@@ -29,6 +29,7 @@ const useUpdateTaskStatus = (handleIconMouseLeave: (() => void) | null) => {
 				shouldInvalidateDashboard && queryClient.invalidateQueries({ queryKey: shouldInvalidateDashboard }),
 				shouldInvalidateDashboardInProgress &&
 					queryClient.invalidateQueries({ queryKey: shouldInvalidateDashboardInProgress }),
+				queryClient.invalidateQueries({ queryKey: ['timeblock'] }),
 			]);
 
 			if (handleIconMouseLeave) handleIconMouseLeave();

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -47,6 +47,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
 	const [selectedTimeBlockId, setSelectedTimeBlockId] = useState<number | null>(null);
 	const [selectdTimeBlockDate, setSelectdTimeBlockDate] = useState<string | null>(null);
+	const [selectedStatus, setSelectedStatus] = useState<(typeof STATUSES)[keyof typeof STATUSES]>(STATUSES.INCOMPLETE);
 
 	const [date, setDate] = useState({ year: today.getFullYear(), month: today.getMonth() + 1 });
 	const [isCalendarPopupOpen, setCalendarPopupOpen] = useState(false);
@@ -128,6 +129,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		if (clickedEvent) {
 			setSelectedTaskId(clickedEvent.extendedProps.taskId);
 			setSelectedTimeBlockId(clickedEvent.extendedProps.timeBlockId);
+			setSelectedStatus(clickedEvent.extendedProps.status);
 			setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr.split('T')[0]));
 			setMainModalOpen(true);
 		}
@@ -197,8 +199,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const updateEvent = (info: EventDropArg | EventResizeDoneArg) => {
 		const { event } = info;
 		const { taskId, timeBlockId } = event.extendedProps;
-		console.log('updateEvent EventDropArg | EventResizeDoneArg', event.startStr);
-		console.log('updateEvent EventDropArg | EventResizeDoneArg', info);
 		if (taskId && taskId !== -1) {
 			let startStr = removeTimezone(event.startStr);
 			let endStr = removeTimezone(event.endStr);
@@ -207,8 +207,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 				startStr += 'T00:00';
 				endStr = startStr;
 			}
-
-			console.log('updateMutate ', taskId, timeBlockId, startStr, endStr, info.event.allDay);
 
 			updateMutate({ taskId, timeBlockId, startTime: startStr, endTime: endStr, isAllTime: info.event.allDay });
 		} else {
@@ -219,8 +217,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const isSelectable = !!selectedTarget;
 
 	const handleDelete = () => {
-		console.log('taskId, timeBlockId', selectedTaskId, selectedTimeBlockId);
-
 		if (selectedTaskId && selectedTimeBlockId) {
 			deleteMutate({ taskId: selectedTaskId, timeBlockId: selectedTimeBlockId });
 		} else {
@@ -443,7 +439,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					top={top}
 					left={left}
 					onClose={closeMainModal}
-					status="미완료"
+					status={selectedStatus}
 					taskId={selectedTaskId}
 					handleStatusEdit={handleStatusEdit}
 					targetDate={selectdTimeBlockDate ? formatDatetoLocalDate(selectdTimeBlockDate) : formatDatetoLocalDate(today)}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -165,6 +165,15 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 				}
 			});
 
+			const start = new Date(selectInfo.startStr);
+			const end = new Date(selectInfo.endStr);
+			const diffInMinutes = (end.getTime() - start.getTime()) / (1000 * 60);
+
+			if (diffInMinutes < 30) {
+				console.log('이벤트 생성 최소 시간 제한: 30분 이상이어야 합니다.'); // (클릭 시 실수로 이벤트 생성되는 것 방지)
+				return;
+			}
+
 			calendarApi.addEvent({
 				id: selectedTarget.id.toString(),
 				title: selectedTarget.name,

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -393,6 +393,8 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					hour12: true,
 				}}
 				slotLabelContent={customSlotLabelContent}
+				scrollTime="06:00:00"
+				scrollTimeReset={false}
 				/* eslint-disable */
 				dayHeaderContent={(arg) => (
 					<DayHeaderContent

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -65,7 +65,27 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const { mutate: updateMutate } = useUpdateTimeBlock();
 	const { mutate: deleteMutate } = useDeleteTimeBlock();
 
-	const calendarEvents = timeBlockData ? processEvents(timeBlockData.data.data, selectedStatuses) : [];
+	// 추후 전역상태로 처리 예정
+	interface EventData {
+		title: string;
+		start: string;
+		end: string;
+		allDay?: boolean;
+		classNames: string;
+		extendedProps: {
+			taskId: number;
+			timeBlockId: number | null;
+			isCompleted: boolean;
+			status: (typeof STATUSES)[keyof typeof STATUSES];
+		};
+	}
+	const [calendarEvents, setCalendarEvents] = useState<EventData[]>([]);
+
+	useEffect(() => {
+		if (timeBlockData) {
+			setCalendarEvents(processEvents(timeBlockData.data.data, selectedStatuses));
+		}
+	}, [timeBlockData, selectedStatuses]);
 
 	useEffect(() => {
 		if (selectDate && calendarRef.current) {
@@ -217,9 +237,13 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 				endStr = startStr;
 			}
 
+			setCalendarEvents((prevEvents) =>
+				prevEvents.map((e) =>
+					e.extendedProps.timeBlockId === timeBlockId ? { ...e, start: startStr, end: endStr } : e
+				)
+			);
+
 			updateMutate({ taskId, timeBlockId, startTime: startStr, endTime: endStr, isAllTime: info.event.allDay });
-		} else {
-			info.revert();
 		}
 	};
 

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -57,6 +57,15 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	);
 	const [isFilterPopupDot, setIsFilterPopupDot] = useState(false);
 	const [isMainModalOpen, setMainModalOpen] = useState(false);
+	const [scrollTime, setScrollTime] = useState<string>(() => {
+		const now = new Date();
+		return now.toTimeString().split(' ')[0]; // "HH:MM:SS" 형식
+	});
+
+	useEffect(() => {
+		const now = new Date();
+		setScrollTime(now.toTimeString().split(' ')[0]);
+	}, []);
 
 	const calendarRef = useRef<FullCalendar>(null);
 
@@ -190,7 +199,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 			const diffInMinutes = (end.getTime() - start.getTime()) / (1000 * 60);
 
 			if (diffInMinutes < 30) {
-				console.log('이벤트 생성 최소 시간 제한: 30분 이상이어야 합니다.'); // (클릭 시 실수로 이벤트 생성되는 것 방지)
+				// (클릭 시 실수로 이벤트 생성되는 것 방지)
 				return;
 			}
 
@@ -417,7 +426,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					hour12: true,
 				}}
 				slotLabelContent={customSlotLabelContent}
-				scrollTime="06:00:00"
+				scrollTime={scrollTime}
 				scrollTimeReset={false}
 				/* eslint-disable */
 				dayHeaderContent={(arg) => (

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -149,6 +149,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	.fc-daygrid-body {
 		width: 100% !important;
+		height: 100%;
 		overflow: hidden;
 
 		border: 1px solid ${({ theme }) => theme.colorToken.Outline.neutralStrong};
@@ -176,11 +177,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 		border-right: none;
 		border-left: none;
-	}
-
-	.fc-scrollgrid-sync-table {
-		width: 100% !important;
-		height: 4rem !important;
 	}
 
 	/* 종일  - 타임그리드 셀 크기 고정 */
@@ -449,13 +445,6 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	/* 타임 그리드 종일 마진 없애기 */
 	.fc .fc-daygrid-body-natural .fc-daygrid-day-events {
 		margin: 0;
-	}
-
-	/* 월간뷰 border 위아래 짤림 커버용 */
-	.month-view .fc-scroller.fc-scroller-liquid-absolute {
-		border-top: 1px solid ${({ theme }) => theme.colorToken.Outline.neutralStrong} !important;
-		border-bottom: 1px solid ${({ theme }) => theme.colorToken.Outline.neutralStrong} !important;
-		border-radius: 12px;
 	}
 
 	/* 월간뷰 스크롤 제거 */

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -346,7 +346,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	/* 종일 이벤트 테두리 */
 	.fc .fc-daygrid-day-frame .fc-event-main {
 		display: flex;
-		align-items: center;
+		align-items: baseline;
 		justify-content: center;
 		box-sizing: border-box;
 		height: 2.1rem;
@@ -596,7 +596,10 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 		background-color: ${({ theme }) => theme.colorToken.Neutral.heavy};
 	}
 
+	/* TimeGrid(주간) all-day-event(종일) 컨테이너 */
 	.fc .fc-h-event {
+		width: 100%;
+
 		border: none;
 	}
 
@@ -607,7 +610,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 	}
 
 	.month-view .fc-all-day-event {
-		width: 72%;
+		width: 99%;
 	}
 
 	/* Month view 중 이벤트 초과 안내 */

--- a/src/components/common/fullCalendar/processEvents.tsx
+++ b/src/components/common/fullCalendar/processEvents.tsx
@@ -11,6 +11,7 @@ interface EventData {
 		taskId: number;
 		timeBlockId: number | null;
 		isCompleted: boolean;
+		status: (typeof STATUSES)[keyof typeof STATUSES];
 	};
 }
 
@@ -32,6 +33,7 @@ const processEvents = (timeBlockData: TimeBlockData, selectedStatuses: string[])
 						taskId: task.id,
 						timeBlockId: timeBlock.id,
 						isCompleted: task.status === STATUSES.COMPLETED,
+						status: task.status,
 					},
 				});
 			});


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- timeblock 클릭 시 모달 오픈하는 과정에서 status가 하드코딩되어있길래 연동시켜두었습니다.
- **task status 변경 시 timeblock ui에 바로 반영**할 수 있도록 쿼리키 연동
- task 클릭 후 캘린더에 긁으면 이벤트가 바로 생성되는 과정에서, 아무 곳이나 클릭만 해도 해당 타임슬롯을 지정했다고 간주하고 이벤트 생성되길래.... 😑 너무 에러같아서 해당 동작 처리하는 **`addEventWhenDragged()` 에서는 15분짜리 이벤트 생성을 막아뒀습니다.**
- 타임그리드 클릭 할 때마다 06:00am으로 스크롤 초기화되는 게 ux상 너무 별로인 것 같아 **스크롤초기화 막아뒀습니다.**
- **timeblock 진행기간 수정 시 깜빡임 문제 해결**
- 캘린더 반응형 처리되도록 css 수정

## 알게된 점 :rocket:

> 기록하며 개발하기!

- timeblock 이동 시 깜빡이는 문제를 계속 쿼리쪽 문제라고 생각하고있었는데 `calendarEvents`가 `timeBlockData`를 기반으로 매번 재생성되면서 발생한 문제였다.. calendarEvents도 상태로 만들어서 즉각 반영 가능하도록 했습니다. 

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- targetDate 연결하는 부분(캘린더내부 캘린더모달 등)은 말이 안되는 프룹스드릴링이 또 일어날거같아서 안했는데요.. 이 pr 올리고 전역상태로 바꾸는 작업을 진행해볼 예정이라 같이 손보겠습니닷. 일단 빠른 ut를 위해

## 관련 이슈

close #407 

## 스크린샷 (선택)
![Mar-10-2025 02-47-00](https://github.com/user-attachments/assets/01da36a0-683e-4e13-9f3f-1febc70c62b8)
