### PR TITLE
[REFACTOR] 쏟아내기 및 마감기한 UX 개선

### DIFF
--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -107,7 +107,7 @@ function DumpingAreaBtn() {
 					disabled={false}
 					label={timeDateChipLabel()}
 					leftIcon={!todoDate && todoTime ? 'IcnPlus' : 'IcnModify'}
-					onClick={handleSettingModal}
+					onMouseDown={handleSettingModal}
 				/>
 			)}
 			{settingModalOpen && (

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -117,7 +117,6 @@ function DumpingAreaBtn() {
 					todoDate={todoDate ? new Date(todoDate) : null}
 					todoTime={todoTime}
 					handleSettingModal={handleSettingModal}
-					onClose={handleSettingModal}
 				/>
 			)}
 			{settingModalOpen && <ModalBackdrop onClick={handleSettingModal} />}

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -114,7 +114,7 @@ function DumpingAreaBtn() {
 				<DueDateModal
 					handleTodoTime={handleTodoTime}
 					handleTodoDate={handleTodoDate}
-					todoDate={todoDate ? new Date(todoDate) : new Date()}
+					todoDate={todoDate ? new Date(todoDate) : null}
 					todoTime={todoTime}
 					handleSettingModal={handleSettingModal}
 					onClose={handleSettingModal}

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -13,7 +13,8 @@ import { INPUT_STATE, InputState } from '@/types/inputStateType';
 import { formatDatetoLocalDate, formatDateWithDay } from '@/utils/formatDateTime';
 
 function DumpingAreaBtn() {
-	const { state, handleFocus, handleBlur, handleChange, handleMouseEnter, handleMouseLeave } = useInputHandler();
+	const { state, handleFocus, handleBlur, handleChange, handleMouseEnter, handleMouseLeave, handleEventDefault } =
+		useInputHandler();
 	const [todoTitle, setTodoTitle] = useState('');
 	const [settingModalOpen, setSettingModalOpen] = useState(false);
 	// 날짜를 별도로 설정하지 않을 경우,
@@ -44,6 +45,11 @@ function DumpingAreaBtn() {
 	const handleEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === 'Enter' && todoTitle.trim() !== '' && !e.nativeEvent.isComposing) {
 			onCreateTask();
+			resetInputs(); // 입력 필드 초기화
+			e.currentTarget.blur(); // 입력 필드에서 포커스 제거
+
+			// 모든 상태를 DEFAULT로 재설정하기 위해 상태를 업데이트
+			handleEventDefault();
 		}
 	};
 
@@ -57,6 +63,7 @@ function DumpingAreaBtn() {
 			},
 		});
 		resetInputs();
+		handleEventDefault();
 	};
 
 	const resetInputs = () => {

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -59,7 +59,7 @@ function DumpingAreaBtn() {
 			name: todoTitle,
 			deadLine: {
 				date: todoDate ? formatDatetoLocalDate(todoDate) : null,
-				time: todoTime || null,
+				time: todoTime.slice(0, 5) || null,
 			},
 		});
 		resetInputs();

--- a/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
+++ b/src/components/common/v2/TextBox/DumpingAreaBtn.tsx
@@ -110,6 +110,7 @@ function DumpingAreaBtn() {
 					todoDate={todoDate ? new Date(todoDate) : new Date()}
 					todoTime={todoTime}
 					handleSettingModal={handleSettingModal}
+					onClose={handleSettingModal}
 				/>
 			)}
 			{settingModalOpen && <ModalBackdrop onClick={handleSettingModal} />}

--- a/src/components/common/v2/button/Button.tsx
+++ b/src/components/common/v2/button/Button.tsx
@@ -18,6 +18,7 @@ type ButtonProps = {
 	label: string;
 	additionalCss?: SerializedStyles;
 	onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+	onMouseDown?: React.MouseEventHandler<HTMLButtonElement>;
 };
 
 function Button({
@@ -29,6 +30,7 @@ function Button({
 	label,
 	additionalCss,
 	onClick,
+	onMouseDown,
 }: ButtonProps) {
 	const { font, color } = useTheme();
 	// 크기별 사이즈
@@ -139,7 +141,7 @@ function Button({
 	};
 
 	return (
-		<ButtonLayout onClick={disabled ? () => {} : onClick}>
+		<ButtonLayout onClick={disabled ? () => {} : onClick} onMouseDown={onMouseDown}>
 			{leftIcon && <Icon name={leftIcon} size={iconSize[size]} />}
 			{label}
 			{rightIcon && <Icon name={rightIcon} size={iconSize[size]} />}

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -8,7 +8,7 @@ import { getRoundedFormattedCurrTime } from '@/utils/time';
 
 interface DueDateModalType {
 	todoTime: string;
-	todoDate?: Date;
+	todoDate: Date | null;
 	handleTodoTime: (selectedTodoTime: string) => void;
 	handleTodoDate: (selectedTodoDate: Date | null) => void;
 	handleSettingModal: () => void;

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -12,8 +12,16 @@ interface DueDateModalType {
 	handleTodoTime: (selectedTodoTime: string) => void;
 	handleTodoDate: (selectedTodoDate: Date | null) => void;
 	handleSettingModal: () => void;
+	onClose: () => void;
 }
-function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, handleSettingModal }: DueDateModalType) {
+function DueDateModal({
+	todoTime,
+	todoDate,
+	handleTodoDate,
+	handleTodoTime,
+	handleSettingModal,
+	onClose,
+}: DueDateModalType) {
 	// 모달 내부 state들, Button 누를시 상위 컴포넌트 state로 들어감
 	const defaultDate = new Date();
 
@@ -41,7 +49,7 @@ function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, hand
 			<DueDateModalHeadLayout>
 				<ModalTopButtonBox>
 					<ButtonBox>
-						<IconButton iconName="IcnX" type="normal" size="small" disabled />
+						<IconButton iconName="IcnX" type="normal" size="small" onClick={onClose} />
 					</ButtonBox>
 				</ModalTopButtonBox>
 			</DueDateModalHeadLayout>

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import Button from '@/components/common/v2/button/Button';
 import IconButton from '@/components/common/v2/IconButton';
 import DeadlineBox from '@/components/common/v2/popup/DeadlineBox';
-import { getDisplayCurrTime, getFormattedCurrTime } from '@/utils/time';
+import { getRoundedFormattedCurrTime } from '@/utils/time';
 
 interface DueDateModalType {
 	todoTime: string;
@@ -28,7 +28,7 @@ function DueDateModal({
 	const dateAfter14Days = defaultDate;
 	dateAfter14Days.setDate(defaultDate.getDate() + 14);
 
-	const [dueDateTime, setDueDateTime] = useState(todoTime || getFormattedCurrTime(defaultDate));
+	const [dueDateTime, setDueDateTime] = useState(todoTime || getRoundedFormattedCurrTime(defaultDate));
 	const [dueDateDate, setDueDateDate] = useState<Date | null>(todoDate || dateAfter14Days);
 
 	const onDueDateSubmit = () => {
@@ -57,7 +57,7 @@ function DueDateModal({
 			<DueDateModalBodyLayout>
 				<DeadlineBox
 					date={dueDateDate || new Date()}
-					endTime={getDisplayCurrTime(defaultDate)}
+					endTime={getRoundedFormattedCurrTime(defaultDate)}
 					label="마감 기간"
 					isDueDate
 					handleDueDateModalTime={handleDueDateModalTime}

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -12,16 +12,8 @@ interface DueDateModalType {
 	handleTodoTime: (selectedTodoTime: string) => void;
 	handleTodoDate: (selectedTodoDate: Date | null) => void;
 	handleSettingModal: () => void;
-	onClose: () => void;
 }
-function DueDateModal({
-	todoTime,
-	todoDate,
-	handleTodoDate,
-	handleTodoTime,
-	handleSettingModal,
-	onClose,
-}: DueDateModalType) {
+function DueDateModal({ todoTime, todoDate, handleTodoDate, handleTodoTime, handleSettingModal }: DueDateModalType) {
 	// 모달 내부 state들, Button 누를시 상위 컴포넌트 state로 들어감
 	const defaultDate = new Date();
 
@@ -49,7 +41,7 @@ function DueDateModal({
 			<DueDateModalHeadLayout>
 				<ModalTopButtonBox>
 					<ButtonBox>
-						<IconButton iconName="IcnX" type="normal" size="small" onClick={onClose} />
+						<IconButton iconName="IcnX" type="normal" size="small" onClick={handleSettingModal} />
 					</ButtonBox>
 				</ModalTopButtonBox>
 			</DueDateModalHeadLayout>

--- a/src/components/common/v2/modal/DueDateModal.tsx
+++ b/src/components/common/v2/modal/DueDateModal.tsx
@@ -57,7 +57,7 @@ function DueDateModal({
 			<DueDateModalBodyLayout>
 				<DeadlineBox
 					date={dueDateDate || new Date()}
-					endTime={getRoundedFormattedCurrTime(defaultDate)}
+					endTime={dueDateTime}
 					label="마감 기간"
 					isDueDate
 					handleDueDateModalTime={handleDueDateModalTime}

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -15,6 +15,7 @@ import useInput from '@/hooks/useInput';
 import useOutsideClick from '@/hooks/useOutsideClick';
 import { StatusType } from '@/types/tasks/taskType';
 import { formatDatetoLocalDate } from '@/utils/formatDateTime';
+import { getRoundedFormattedCurrTime } from '@/utils/time';
 
 interface MainSettingModalProps {
 	isOpen: boolean;
@@ -218,7 +219,7 @@ function MainSettingModal({
 				<MainSettingModalBodyLayout>
 					<DeadlineBox
 						date={deadlineDate || new Date()}
-						endTime={deadlineTime || '23:59'}
+						endTime={deadlineTime || getRoundedFormattedCurrTime(new Date())}
 						handleDueDateModalDate={handleDeadlineDate}
 						handleDueDateModalTime={handleDeadlineTime}
 						label="마감 기간"

--- a/src/components/common/v2/popup/DateTimeBtn.tsx
+++ b/src/components/common/v2/popup/DateTimeBtn.tsx
@@ -37,7 +37,7 @@ function DateTimeBtn({
 
 	const updateEndTime = (newTime: string) => {
 		onEndTimeChange(`${formatDatetoLocalDate(date)}T${newTime.slice(0, 5)}`);
-		handleDueDateModalTime(newTime.slice(0, 5));
+		handleDueDateModalTime(newTime);
 	};
 
 	const updateDate = (newDate: Date) => {

--- a/src/hooks/useInputHandler.ts
+++ b/src/hooks/useInputHandler.ts
@@ -39,6 +39,10 @@ function useInputHandler() {
 		}
 	};
 
+	const handleEventDefault = () => {
+		setState(INPUT_STATE.DEFAULT);
+	};
+
 	return {
 		state,
 		handleFocus,
@@ -46,6 +50,7 @@ function useInputHandler() {
 		handleChange,
 		handleMouseEnter,
 		handleMouseLeave,
+		handleEventDefault,
 	};
 }
 

--- a/src/utils/generateQuarterTimes.ts
+++ b/src/utils/generateQuarterTimes.ts
@@ -4,7 +4,8 @@ const generateQuarterTimes = () => {
 	for (let hour = 0; hour < 24; hour += 1) {
 		for (let minute = 0; minute < 60; minute += 15) {
 			const period = hour < 12 ? 'am' : 'pm';
-			const formattedHour = hour.toString().padStart(2, '0');
+			const hours12format = hour % 12 || 12;
+			const formattedHour = hours12format.toString().padStart(2, '0');
 			const formattedMinute = minute.toString().padStart(2, '0');
 			times.push(`${formattedHour}:${formattedMinute} ${period}`);
 		}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -21,3 +21,20 @@ export const getFormattedCurrTime = (date: Date) => {
 	const { formattedHours, formattedMinutes } = getCurrTime(date);
 	return `${formattedHours}:${formattedMinutes}`;
 };
+
+/** 15분 단위로 올림 된 hh:mm am, hh:mm pm 형식 */
+export const getRoundedFormattedCurrTime = (date: Date) => {
+	let hours = date.getHours();
+	let minutes = date.getMinutes();
+	minutes = Math.ceil(minutes / 15) * 15;
+
+	if (minutes === 60) {
+		minutes = 0;
+		hours = (hours + 1) % 24;
+	}
+
+	const formatted12Hours = (hours % 12 || 12).toString().padStart(2, '0');
+	const formattedRoundedMinutes = minutes.toString().padStart(2, '0');
+	const period = hours >= 12 ? 'pm' : 'am';
+	return `${formatted12Hours}:${formattedRoundedMinutes}${period}`;
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 쏟아내기 창 밑의 마감기한 모달 open/close 관련 클릭이벤트 개선
- 마감기한 모달의 '시간' 부분 데이터 UI연동 
- 마감기한 모달 오픈 시, 현재 시간을 15분 단위로 올림하여 표시
- 마감기한 모달 x 버튼 활성화

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 임시로 박아둔 값들이 진짜 많이 고ㅣ롭히네요.,,,,

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 

## 관련 이슈

close #411 

## 스크린샷 (선택)
![Mar-13-2025 17-27-25](https://github.com/user-attachments/assets/467cdd50-8ddd-4673-a4ea-24a6f5ec3191)
