### PR TITLE
[FIX] main setting modal 상태 관리

### DIFF
--- a/src/apis/tasks/editTask/query.ts
+++ b/src/apis/tasks/editTask/query.ts
@@ -16,7 +16,7 @@ const usePatchTaskDescription = () => {
 			}),
 	});
 
-	return { mutate: mutation.mutate, queryClient };
+	return { mutate: mutation.mutate, queryClient, mutateAsync: mutation.mutateAsync };
 };
 
 export default usePatchTaskDescription;

--- a/src/apis/tasks/taskDescription/query.ts
+++ b/src/apis/tasks/taskDescription/query.ts
@@ -11,6 +11,7 @@ const useTaskDescription = ({ taskId, targetDate, isOpen }: TaskDescriptionType)
 		queryKey: QUERY_KEYS.taskDescription(taskId, targetDate),
 		queryFn: () => taskDescription({ taskId, targetDate }),
 		enabled: isOpen,
+		staleTime: 0,
 	});
 
 	return data;

--- a/src/apis/tasks/taskDescription/query.ts
+++ b/src/apis/tasks/taskDescription/query.ts
@@ -11,7 +11,6 @@ const useTaskDescription = ({ taskId, targetDate, isOpen }: TaskDescriptionType)
 		queryKey: QUERY_KEYS.taskDescription(taskId, targetDate),
 		queryFn: () => taskDescription({ taskId, targetDate }),
 		enabled: isOpen,
-		staleTime: 0,
 	});
 
 	return data;

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -19,8 +19,6 @@ const usePatchTimeBlock = () => {
 				endTime = formatDateToLocal(startDate);
 			}
 
-			console.log('usePatchTimeBlock ', taskId, timeBlockId, startTime, endTime, isAllTime);
-
 			const response = await PatchTimeBlock({ taskId, timeBlockId, startTime, endTime, isAllTime });
 			if (response && response.code === 'conflict') {
 				addToast(response.message, response.code);

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import PatchTimeBlock from './axios';
 import { PatchTimeBlokType } from './PatchTimeBlockType';
 
+import QUERY_KEYS from '@/apis/queryKeys';
 import { useToast } from '@/components/toast/ToastContext';
 import { formatDateToLocal } from '@/utils/formatDateTime';
 
@@ -26,7 +27,12 @@ const usePatchTimeBlock = () => {
 			}
 			return response;
 		},
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['timeblock'] }),
+		onSuccess: (_response, variables) => {
+			const { taskId, startTime } = variables;
+			const targetDate = formatDateToLocal(new Date(startTime)).split('T')[0];
+
+			queryClient.invalidateQueries({ queryKey: QUERY_KEYS.taskDescription(taskId, targetDate) });
+		},
 	});
 
 	return { mutate: mutation.mutate };

--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -10,7 +10,7 @@ const BtnTaskContainer = styled.div<{ type: string }>`
 	align-items: center;
 	box-sizing: border-box;
 	width: 100%;
-	height: 100%;
+	height: 90%;
 	max-height: 82rem;
 	padding-left: 0.8rem;
 	overflow: auto;

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -15,7 +15,6 @@ import CalendarHeader from './CalendarHeader';
 import CustomDayCellContent from './CustomDayCellContent';
 import processEvents from './processEvents';
 
-import useUpdateTaskStatus from '@/apis/tasks/updateTaskStatus/query';
 import useDeleteTimeBlock from '@/apis/timeBlocks/deleteTimeBlock/query';
 import useGetTimeBlock from '@/apis/timeBlocks/getTimeBlock/query';
 import usePostTimeBlock from '@/apis/timeBlocks/postTimeBlock/query';
@@ -25,7 +24,7 @@ import FullCalendarLayout from '@/components/common/fullCalendar/FullCalendarSty
 import customSlotLabelContent from '@/components/common/fullCalendar/fullCalendarUtils';
 import MODAL from '@/constants/modalLocation';
 import { STATUSES } from '@/constants/statuses';
-import { StatusType, TaskType } from '@/types/tasks/taskType';
+import { TaskType } from '@/types/tasks/taskType';
 import { formatDateToLocal, formatDatetoLocalDate } from '@/utils/formatDateTime';
 
 interface FullCalendarBoxProps {
@@ -368,15 +367,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		arg.el.addEventListener('contextmenu', (event) => handleRightClick(arg, event));
 	};
 
-	const { mutate: updateStateMutate } = useUpdateTaskStatus(null);
-
-	const handleStatusEdit = (newStatus: StatusType) => {
-		if (selectedTaskId !== null) {
-			const targetDate = selectDate ? selectDate.toISOString().split('T')[0] : todayDate;
-			updateStateMutate({ taskId: selectedTaskId, targetDate, status: newStatus });
-		}
-	};
-
 	return (
 		<FullCalendarLayout size={size} currentView={currentView}>
 			<CalendarHeader
@@ -485,7 +475,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					onClose={closeMainModal}
 					status={selectedStatus}
 					taskId={selectedTaskId}
-					handleStatusEdit={handleStatusEdit}
 					targetDate={selectdTimeBlockDate ? formatDatetoLocalDate(selectdTimeBlockDate) : formatDatetoLocalDate(today)}
 					timeBlockId={selectedTimeBlockId}
 					isAllTime={calendarEvents.find((event) => event.extendedProps.taskId === selectedTaskId)?.allDay || false}

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -173,7 +173,7 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 
 	.fc .fc-col-header-cell {
 		height: 2.4rem;
-		padding: 2rem 0.8rem 0;
+		padding: 1.6rem 0.8rem 0;
 
 		border-right: none;
 		border-left: none;

--- a/src/components/common/v2/TextBox/PopUp.tsx
+++ b/src/components/common/v2/TextBox/PopUp.tsx
@@ -13,14 +13,14 @@ const TYPE = {
 type PopUpProps = {
 	type: (typeof TYPE)[keyof typeof TYPE];
 	defaultValue?: string;
-	onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+	onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 };
 
 function PopUp({ type, defaultValue, onChange = () => {} }: PopUpProps) {
 	const { state, handleFocus, handleBlur, handleChange } = useInputHandler();
 	const placeholder = type === TYPE.TITLE ? '제목을 입력하세요' : '설명을 추가하세요';
 
-	const handlePopUpChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+	const handlePopUpChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
 		onChange(e);
 		handleChange(e);
 	};
@@ -37,6 +37,7 @@ function PopUp({ type, defaultValue, onChange = () => {} }: PopUpProps) {
 					handlePopUpChange(e);
 				}}
 				defaultValue={defaultValue}
+				maxLength={100}
 			/>
 		</PopUpContainer>
 	);
@@ -49,9 +50,11 @@ const PopUpContainer = styled.div`
 	flex-direction: row;
 	gap: 8px;
 	align-items: center;
+	width: 100%;
 `;
 
-const StyledInput = styled.input<{ type: PopUpProps['type']; state: InputState }>`
+const StyledInput = styled.textarea<{ type: PopUpProps['type']; state: InputState }>`
+	width: 100%;
 	${({ type, theme }) => (type === TYPE.TITLE ? theme.font.title02 : theme.font.body03)};
 	caret-color: ${({ theme }) => theme.color.Blue.Blue7};
 
@@ -71,6 +74,8 @@ const StyledInput = styled.input<{ type: PopUpProps['type']; state: InputState }
 
 	outline: none;
 	border-width: 0;
+
+	resize: none;
 
 	&::placeholder {
 		color: ${({ state, theme }) => (state === INPUT_STATE.DEFAULT ? theme.color.Grey.Grey6 : theme.color.Grey.Grey4)};

--- a/src/components/common/v2/dropdown/TimeDropdown.tsx
+++ b/src/components/common/v2/dropdown/TimeDropdown.tsx
@@ -1,21 +1,60 @@
+import { css, useTheme, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useEffect, useRef } from 'react';
 
 import Button from '@/components/common/v2/button/Button';
+import formatToHHMM from '@/utils/formatTime';
 import quarterTimes from '@/utils/generateQuarterTimes';
 
 interface TimeDropdownProps {
 	handleSelectTime: (time: string) => void;
+	selectedTime: string;
 }
 
-function TimeDropdown({ handleSelectTime }: TimeDropdownProps) {
+function TimeDropdown({ handleSelectTime, selectedTime }: TimeDropdownProps) {
+	const theme = useTheme();
+	const selectedTimeRef = useRef<HTMLDivElement | null>(null);
+	const containerRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (selectedTimeRef.current) {
+			selectedTimeRef.current.scrollIntoView({
+				behavior: 'instant',
+				block: 'start',
+			});
+
+			if (containerRef.current) {
+				containerRef.current.scrollTop -= 10;
+			}
+		}
+	}, []);
+
+	const formattedSelectedTime = formatToHHMM(selectedTime);
+
 	return (
-		<TimeDropdownContainer>
-			{quarterTimes.map((time) => (
-				<Button key={time} label={time} onClick={() => handleSelectTime(time)} size="large" type="text-assistive" />
-			))}
+		<TimeDropdownContainer ref={containerRef}>
+			{quarterTimes.map((time) => {
+				const isSelected = time.startsWith(formattedSelectedTime);
+
+				return (
+					<div key={time} ref={isSelected ? selectedTimeRef : null}>
+						<Button
+							label={time}
+							onClick={() => handleSelectTime(time)}
+							size="large"
+							type="text-assistive"
+							additionalCss={btnCustomWidth(isSelected, theme)}
+						/>
+					</div>
+				);
+			})}
 		</TimeDropdownContainer>
 	);
 }
+
+const btnCustomWidth = (isSelected: boolean, theme: Theme) => css`
+	background-color: ${isSelected ? theme.color.Grey.Grey3 : 'transparent'};
+`;
 
 const TimeDropdownContainer = styled.div`
 	box-sizing: border-box;

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -129,7 +129,7 @@ function MainSettingModal({
 	};
 
 	const handleConfirm = () => {
-		if (!isvalidTimeRange(startTime, endTime)) {
+		if (isTimeBlockSelected && !isvalidTimeRange(startTime, endTime)) {
 			addToast('시작 시간이 종료 시간보다 클 수 없어요.', 'error');
 			onClose();
 			return;

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -42,7 +42,7 @@ function MainSettingModal({
 	isAllTime = false,
 }: MainSettingModalProps) {
 	const { mutate: deleteMutate } = useDeleteTask();
-	const { mutate: editMutate } = usePatchTaskDescription();
+	const { mutateAsync: editMutate } = usePatchTaskDescription();
 	const { mutate: updateTimeBlockMutate } = useUpdateTimeBlock();
 	const { data: taskDetailData, isFetched: isTaskDetailFetched } = useTaskDescription({ taskId, targetDate, isOpen });
 	const { mutate: updateStateMutate } = useUpdateTaskStatus(null);
@@ -131,23 +131,21 @@ function MainSettingModal({
 	};
 
 	const handleEdit = async () => {
-		await new Promise((resolve) => {
-			editMutate(
-				{
-					taskId,
-					name: titleContent,
-					description: descriptionContent,
-					deadLine: {
-						date: formatDatetoLocalDate(deadlineDate) || null,
-						time: deadlineTime || null,
-					},
+		try {
+			await editMutate({
+				taskId,
+				name: titleContent,
+				description: descriptionContent,
+				deadLine: {
+					date: formatDatetoLocalDate(deadlineDate) || null,
+					time: deadlineTime || null,
 				},
-				{
-					onSuccess: resolve,
-				}
-			);
-		});
-		handleStatusEdit(taskStatus); // task 상세 수정 완료 후 상태 변경 실행
+			});
+
+			handleStatusEdit(taskStatus);
+		} catch (error) {
+			console.error(error);
+		}
 	};
 
 	const handleTaskStatusChange = (newStatus: StatusType) => {

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -12,6 +12,7 @@ import DropdownButton from '@/components/common/v2/control/DropdownButton';
 import IconButton from '@/components/common/v2/IconButton';
 import DeadlineBox from '@/components/common/v2/popup/DeadlineBox';
 import PopUp from '@/components/common/v2/TextBox/PopUp';
+import { useToast } from '@/components/toast/ToastContext';
 import useInput from '@/hooks/useInput';
 import useOutsideClick from '@/hooks/useOutsideClick';
 import { StatusType } from '@/types/tasks/taskType';
@@ -115,7 +116,21 @@ function MainSettingModal({
 		}
 	};
 
+	const { addToast } = useToast();
+
+	const isvalidTimeRange = (start: string, end: string) => {
+		const startDate = new Date(start);
+		const endDate = new Date(end);
+		return startDate <= endDate;
+	};
+
 	const handleConfirm = () => {
+		if (!isvalidTimeRange(startTime, endTime)) {
+			addToast('시작 시간이 종료 시간보다 클 수 없어요.', 'error');
+			onClose();
+			return;
+		}
+
 		handleEdit();
 		handleTimeBlockUpdate();
 		onClose();

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -160,7 +160,7 @@ function MainSettingModal({
 				description: descriptionContent,
 				deadLine: {
 					date: formatDatetoLocalDate(deadlineDate) || null,
-					time: deadlineTime || null,
+					time: deadlineTime.slice(0, 5) || null,
 				},
 			});
 
@@ -263,9 +263,12 @@ function MainSettingModal({
 }
 
 const MainSettingModalLayout = styled.article<{ top: number; left: number }>`
-	position: fixed;
+	/* position: fixed;
 	top: ${({ top }) => top}px;
-	left: ${({ left }) => left}px;
+	left: ${({ left }) => left}px; */
+	position: fixed;
+	top: 50%;
+	left: 50%;
 	z-index: 5;
 	display: flex;
 	flex-direction: column;
@@ -279,6 +282,7 @@ const MainSettingModalLayout = styled.article<{ top: number; left: number }>`
 	box-shadow:
 		4px 4px 40px 20px #717e9833,
 		-4px -4px 40px 0 #717e9833;
+	transform: translate(-50%, -50%);
 	border-radius: 20px;
 `;
 

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -45,7 +45,11 @@ function MainSettingModal({
 	const { mutate: deleteMutate } = useDeleteTask();
 	const { mutateAsync: editMutate } = usePatchTaskDescription();
 	const { mutate: updateTimeBlockMutate } = useUpdateTimeBlock();
-	const { data: taskDetailData, isFetched: isTaskDetailFetched } = useTaskDescription({ taskId, targetDate, isOpen });
+	const {
+		data: taskDetailData,
+		isFetched: isTaskDetailFetched,
+		refetch,
+	} = useTaskDescription({ taskId, targetDate, isOpen });
 	const { mutate: updateStateMutate } = useUpdateTaskStatus(null);
 
 	const [taskStatus, setTaskStatus] = useState(status);
@@ -63,9 +67,9 @@ function MainSettingModal({
 		onChange: onDescriptionChange,
 		handleContent: handleDesc,
 	} = useInput(taskDetailData?.description || '');
-	const { content: deadlineTime, handleContent: handleDeadlineTime } = useInput(taskDetailData?.deadLine?.time || '');
-	const { content: startTime, handleContent: handleStartTime } = useInput(taskDetailData?.timeBlock?.startTime || '');
-	const { content: endTime, handleContent: handleEndTime } = useInput(taskDetailData?.timeBlock?.endTime || '');
+	const { content: deadlineTime, handleContent: handleDeadlineTime } = useInput('');
+	const { content: startTime, handleContent: handleStartTime } = useInput('');
+	const { content: endTime, handleContent: handleEndTime } = useInput('');
 
 	const [deadlineDate, setDeadlineDate] = useState<Date | null>(
 		taskDetailData?.deadLine?.date ? new Date(taskDetailData.deadLine.date) : null
@@ -160,6 +164,7 @@ function MainSettingModal({
 			});
 
 			handleStatusEdit(taskStatus);
+			refetch();
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -131,7 +131,7 @@ function MainSettingModal({
 
 	const handleConfirm = () => {
 		if (isTimeBlockSelected && !isvalidTimeRange(startTime, endTime)) {
-			addToast('시작 시간이 종료 시간보다 클 수 없어요.', 'error');
+			addToast('시작 시간은 종료 시간 이전이어야 합니다.', 'error');
 			onClose();
 			return;
 		}

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -89,7 +89,7 @@ function MainSettingModal({
 			setShouldOpenModal(true);
 			setIsTimeBlockSelected(!!taskDetailData?.timeBlock);
 		}
-	}, [taskDetailData, isTaskDetailFetched]);
+	}, [taskDetailData, isTaskDetailFetched, isOpen]);
 
 	useEffect(() => {
 		setTaskStatus(status);

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -70,6 +70,7 @@ function MainSettingModal({
 		taskDetailData?.deadLine?.date ? new Date(taskDetailData.deadLine.date) : null
 	);
 	const [timeBlockDate, setTimeBlockDate] = useState<Date | null>(new Date(targetDate));
+	const [isTimeBlockSelected, setIsTimeBlockSelected] = useState(!!timeBlockId);
 
 	useEffect(() => {
 		if (isTaskDetailFetched && taskDetailData) {
@@ -81,6 +82,7 @@ function MainSettingModal({
 
 			setDeadlineDate(taskDetailData?.deadLine?.date ? new Date(taskDetailData.deadLine.date) : null);
 			setShouldOpenModal(true);
+			setIsTimeBlockSelected(!!taskDetailData?.timeBlock);
 		}
 	}, [taskDetailData, isTaskDetailFetched]);
 
@@ -214,13 +216,13 @@ function MainSettingModal({
 					<PopUpTitleBox>
 						<PopUp type="description" defaultValue={descriptionContent} onChange={onDescriptionChange} />
 					</PopUpTitleBox>
-					{timeBlockId && (
+					{isTimeBlockSelected && (
 						<DeadlineBox
 							date={timeBlockDate || new Date(targetDate)}
 							startTime={formatTimeWithAmPm(startTime) || '23:59'}
 							endTime={formatTimeWithAmPm(endTime) || '23:59'}
 							label="진행 기간"
-							isDueDate={!!timeBlockId}
+							isDueDate={!!isTimeBlockSelected}
 							isAllDay={isAllDay}
 							onAllDayToggle={handleAllDayToggle}
 							onStartTimeChange={handleStartTime}

--- a/src/components/common/v2/popup/DeadlineBox.tsx
+++ b/src/components/common/v2/popup/DeadlineBox.tsx
@@ -41,6 +41,7 @@ function DeadlineBox({
 	const [isAllday, setIsAllday] = useState(isAllDay);
 
 	const containerRef = useRef(null);
+	const isProgressPeriod = label === '진행 기간';
 
 	const handlePlusBtnClick = () => {
 		handleDueDateModalTime(endTime);
@@ -120,7 +121,7 @@ function DeadlineBox({
 							onStartTimeChange={onStartTimeChange}
 							onEndTimeChange={onEndTimeChange}
 						/>
-						{isClicked && (
+						{isClicked && isProgressPeriod && (
 							<CheckButton label="하루종일" size="small" checked={isAllday} onClick={handleCheckBtnClick} />
 						)}
 					</>

--- a/src/components/common/v2/popup/TimeBtn.tsx
+++ b/src/components/common/v2/popup/TimeBtn.tsx
@@ -35,7 +35,7 @@ function TimeBtn({ time, setTime }: TimeBtnProps) {
 			</TimeBtnLayout>
 			{isOpen && (
 				<StyledTimeDropdown>
-					<TimeDropdown handleSelectTime={handleSelectTime} />
+					<TimeDropdown handleSelectTime={handleSelectTime} selectedTime={time} />
 				</StyledTimeDropdown>
 			)}
 		</TimeBtnWrapper>

--- a/src/components/common/v2/taskBox/Todo.tsx
+++ b/src/components/common/v2/taskBox/Todo.tsx
@@ -112,7 +112,6 @@ function Todo({
 				onClose={handleCloseModal}
 				taskId={taskId}
 				status={status}
-				handleStatusEdit={handleStatusEdit}
 				targetDate={targetDate}
 			/>
 		</>

--- a/src/components/common/v2/taskBox/Todo.tsx
+++ b/src/components/common/v2/taskBox/Todo.tsx
@@ -126,6 +126,7 @@ const baseStyles = ({ theme }: { theme: Theme }) => css`
 	align-items: flex-start;
 	box-sizing: border-box;
 	width: 100%;
+	min-width: 43.2rem;
 
 	background-color: ${theme.colorToken.Component.normal};
 	border-radius: 12px;

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 const useInput = (defaultValue?: string) => {
 	const [content, setContent] = useState<string>(defaultValue || '');
-	const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+	const onChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
 		if (e.target.value) {
 			setContent(e.target.value);
 		}

--- a/src/hooks/useInputHandler.ts
+++ b/src/hooks/useInputHandler.ts
@@ -2,16 +2,18 @@ import { useState } from 'react';
 
 import { INPUT_STATE, InputState } from '@/types/inputStateType.ts';
 
+type InputElement = HTMLInputElement | HTMLTextAreaElement;
+
 function useInputHandler() {
 	const [state, setState] = useState<InputState>(INPUT_STATE.DEFAULT);
 
-	const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+	const handleFocus = (e: React.FocusEvent<InputElement>) => {
 		if (!e.target.value) {
 			setState(INPUT_STATE.PLACEHOLDER);
 		}
 	};
 
-	const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+	const handleBlur = (e: React.FocusEvent<InputElement>) => {
 		if (e.target.value) {
 			setState(INPUT_STATE.FIELD);
 		} else {
@@ -19,7 +21,7 @@ function useInputHandler() {
 		}
 	};
 
-	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+	const handleChange = (e: React.ChangeEvent<InputElement>) => {
 		if (e.target.value) {
 			setState(INPUT_STATE.TYPING);
 		} else {

--- a/src/stories/Common/dropdown/TimeDropdown.stories.ts
+++ b/src/stories/Common/dropdown/TimeDropdown.stories.ts
@@ -17,6 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
 	args: {
+		selectedTime: '12:00',
 		handleSelectTime: () => {},
 	},
 };

--- a/src/stories/modal/MainSettingModal.stories.ts
+++ b/src/stories/modal/MainSettingModal.stories.ts
@@ -23,7 +23,6 @@ export const Default: Story = {
 		taskId: 1,
 		onClose: () => {},
 		status: '진행중',
-		handleStatusEdit: () => {},
 		targetDate: '2025-01-22',
 	},
 };

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,0 +1,7 @@
+// 주어진 시간 문자열("0:00")을 "00:00" 형식의 문자열로 변환합니다.
+const formatToHHMM = (time: string): string => {
+	const [hour, minute] = time.split(':');
+	return `${hour.padStart(2, '0')}:${minute}`;
+};
+
+export default formatToHHMM;

--- a/src/utils/formatTimeWithAmPm.ts
+++ b/src/utils/formatTimeWithAmPm.ts
@@ -1,0 +1,21 @@
+/**
+ *
+ * @param time (yyyy-mm-ddThh:mm)
+ * @returns (hh:mm am/pm)
+ */
+const formatTimeWithAmPm = (time: string) => {
+	if (/^\d{1,2}:\d{2} (am|pm)$/i.test(time)) {
+		return time; // 이미 포맷된 값이므로 바로 반환
+	}
+
+	if (time) {
+		const onlyTime = time.split('T')[1];
+		const [hour, minute] = onlyTime.split(':').map(Number);
+		const period = hour >= 12 ? 'pm' : 'am';
+		return `${hour}:${minute.toString().padStart(2, '0')} ${period}`;
+	}
+	// 임시 리턴
+	return '06:00pm';
+};
+
+export default formatTimeWithAmPm;

--- a/src/utils/generateQuarterTimes.ts
+++ b/src/utils/generateQuarterTimes.ts
@@ -4,8 +4,7 @@ const generateQuarterTimes = () => {
 	for (let hour = 0; hour < 24; hour += 1) {
 		for (let minute = 0; minute < 60; minute += 15) {
 			const period = hour < 12 ? 'am' : 'pm';
-			const hours12format = hour % 12 || 12;
-			const formattedHour = hours12format.toString().padStart(2, '0');
+			const formattedHour = hour.toString().padStart(2, '0');
 			const formattedMinute = minute.toString().padStart(2, '0');
 			times.push(`${formattedHour}:${formattedMinute} ${period}`);
 		}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -33,8 +33,8 @@ export const getRoundedFormattedCurrTime = (date: Date) => {
 		hours = (hours + 1) % 24;
 	}
 
-	const formatted12Hours = (hours % 12 || 12).toString().padStart(2, '0');
+	const formatted12Hours = hours.toString().padStart(2, '0');
 	const formattedRoundedMinutes = minutes.toString().padStart(2, '0');
 	const period = hours >= 12 ? 'pm' : 'am';
-	return `${formatted12Hours}:${formattedRoundedMinutes}${period}`;
+	return `${formatted12Hours}:${formattedRoundedMinutes} ${period}`;
 };


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 모달 상세 내용 수정 완료 후, 모달을 닫았다가 다시 열면 이전 수정된 데이터가 반영되지 않고, 기존 데이터를 그대로 사용하는 문제가 발생했습니다.
  - 기존 코드에서는 `TaskDetailFetched`와 `isOpen`만을 의존성 배열에 넣어서 `taskDetailData` 변경이 반영되지 않는 문제 발생했고,  `taskDetailData`를 의존성 배열에 추가하여, `taskDetailData`가 변경될 때마다 최신 상태로 반영하도록 수정했습니다.
  - 추가적으로 조건문에 if (isTaskDetailFetched && taskDetailData)를 통해서 taskDetailData가 있을 때만 데이터를 설정하도록 수정했습니다.
- 이전 코드는 Promise를 직접 생성하여 mutate 함수의 onSuccess 콜백을 통해 Promise를 해결하도록 구현지만 부분적으로(캘린더에서 모달을 수정하는 경우) API 호출은 성공했지만 onSuccess 콜백이 호출되지 않아 handleStatusEdit함수가 호출되지 않는 상황이 발생하여 이를 해결하기 위해 mutateAsync를 사용하여  Promise가 명확하게 resolve되거나 reject되도록 할 수 있도록 하였습니다.

  수정 전 코드
    ``` tsx
    const { mutate: editMutate } = usePatchTaskDescription();
    const handleEdit = async () => {
		    await new Promise((resolve) => {
			    editMutate(
				    {
					    taskId,
					    name: titleContent,
					    description: descriptionContent,
					    deadLine: {
						    date: formatDatetoLocalDate(deadlineDate) || null,
						    time: deadlineTime || null,
					    },
				    },
				    {
					    onSuccess: resolve,
				    }
			    );
		    });
		    handleStatusEdit(taskStatus); // task 상세 수정 완료 후 상태 변경 실행
	    };
    ```
      
  수정 후 코드

     ``` tsx
      const { mutateAsync: editMutate } = usePatchTaskDescription();
      const handleEdit = async () => {
		      try {
			      await editMutate({
				      taskId,
				      name: titleContent,
				      description: descriptionContent,
				      deadLine: {
					      date: formatDatetoLocalDate(deadlineDate) || null,
					      time: deadlineTime || null,
      
      
				      },
			      });
      
			      handleStatusEdit(taskStatus);
		      } catch (error) {
			      console.error(error);
		      }
	      };
      ```
- 진행 시간 지정시 유효한 시간 범위인지 확인하는 로직을 추가하였습니다. (`startDate <= endDate`;)
  - 유효하지 않은 경우 에러 토스트를 띄웠습니다.
- TimeDropdown에서 선택한 시간의 background를 추가하였습니다. 또한 해당 모달을 열었을 때 선택한 시간이 가장 위에 위치하도록 선택한 시간에 `ref={isSelected ? selectedTimeRef : null}`를 추가했습니다.
- 상세 타이틀 및 상세 설명 란이 input태그로 이루어져 있어서 width가 넘어가게 글을 작성해도 아래줄로 넘어가지 않아서 이를 textarea로 수정했습니다

## 알게된 점 :rocket:

> 기록하며 개발하기!

- `useMutation`에 `mutateAsync`라는 비동기 API 호출을 Promise 기반으로 처리할 수 있도록 해주는 훅이 있다는 것을 알게되었습니다.
- 현재 모달 상태 관련해서 
  - 작업 상태(status)
  - 작업 타이틀, 설명, 마감기한
  - 작업 진행기간
- 해당 3가지 정보다 다 다른 api로 수정을 하고 있어서 상태 관리에 어려움을 겪었던 것 같습니다,, 사실 해당 모달 상세 수정을 한 api로 수정한다면 상태관리가 더욱 윤택해질것이라 생각하지만 일단 현 상황에서 모달 관련한 상태관리는 오류가 나지 않도록 만들어놨습니다.


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 진행 시간 지정시 유효한 시간 범위가 아닐 경우,  "시작 시간이 종료 시간보다 클 수 없어요." 라는 토스트 문구가 나타나도록 했는데 해당 문구보다 더 좋은 문구가 있다면 추천 부탁드립니당.

## 관련 이슈

close #410

## 스크린샷 (선택)
![Mar-14-2025 16-12-53](https://github.com/user-attachments/assets/e0d9c9a8-6426-4464-ad9a-bcdfb3590749)
