### PR TITLE
[CHORE] develop 브랜치 내역 자동 배포 CICD 설정

### DIFF
--- a/.github/workflows/test-link-deploy.yml
+++ b/.github/workflows/test-link-deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to Test Link
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy_test_link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source repository (팀 레포)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Push changes to test repository
+        env:
+          GIT_USER: 'github-actions[bot]'
+          GIT_EMAIL: 'github-actions[bot]@users.noreply.github.com'
+          TEST_REPO: ${{ secrets.TEST_REPO_URL }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          git config --global user.name "$GIT_USER"
+          git config --global user.email "$GIT_EMAIL"
+          git remote add test "$TEST_REPO"
+          git fetch test
+          git push --force test develop


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- PR단위마다 서비스 링크에 배포를 진행할 순 없으므로 팀 내(타 파트에게) 개발 진행상황 공유를 위해, develop 브랜치 내용과 연결되는 테스트링크를 배포했습니다.
- organization 레포 배포 시 발생하는 버셀 비용 이슈로,, 개인 레포로 포크떠서 배포 진행했습니다. 
(링크: https://shellin-client.vercel.app/)
- 개인 레포에 자동적으로 업데이트 하기 위해 cicd 설정해두었습니다. **develop에 푸시 시 발동합니다.**
    ```yml
    on:
      push:
        branches:
          - develop
    ```
- 항상 같은 내역을 유지하기 위해 배포용 레포에는 force push로 내역 업데이트합니다.
    ```yml
    git push --force test develop
    ```

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 버셀도 로그 확인하기가 굉장히 깔끔한 것 같습니다.
- 이런 cicd 설정 시 발생하는 커밋 작성자를 깃헙 봇(github-actions[bot])으로 설정할 수 있다는 걸 알게됐습니다!

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 현재는 서버에서 cors 등록 전이라, 로그인 화면까지만 접근 가능합니다! 구글로그인 버튼 누르면 cors 뜰거에요
- 더 추가하고싶은 설정 있다면 말해주세요!!

## 관련 이슈

close #414 

## 스크린샷 (선택)
<img width="1287" alt="스크린샷 2025-03-15 00 42 49" src="https://github.com/user-attachments/assets/eba1b9d6-3d20-43dd-82e1-6e53096e6d72" />
