### PR TITLE
[FIX] 모달 항상 중앙에 뜨도록 수정

### DIFF
--- a/src/components/common/BtnTaskContainer.tsx
+++ b/src/components/common/BtnTaskContainer.tsx
@@ -13,8 +13,7 @@ const BtnTaskContainer = styled.div<{ type: string }>`
 	height: 90%;
 	max-height: 82rem;
 	padding-left: 0.8rem;
-	overflow: auto;
-	overflow-y: scroll;
+	overflow: hidden scroll;
 
 	::-webkit-scrollbar {
 		width: 0.6rem;

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -55,7 +55,6 @@ const StagingAreaLayout = styled.div<{ isOpen: boolean }>`
 	align-items: flex-start;
 	box-sizing: border-box;
 	width: ${({ isOpen }) => (isOpen ? '44.8rem' : '0')};
-	overflow: hidden;
 
 	background-color: ${({ theme }) => theme.color.Grey.White};
 	border-right: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -1,4 +1,3 @@
-import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Droppable } from 'react-beautiful-dnd';
 
@@ -46,40 +45,22 @@ export default StagingArea;
 const SizedWrapper = styled.div`
 	width: 100%;
 `;
-const slideIn = keyframes`
-  from {
-    transform: translateX(-100%);
-	display: none;
-  }
-  to {
-    transform: translateX(0);
-  }
-`;
-
-const slideOut = keyframes`
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-100%);
-	display: none;
-  }
-`;
 
 const StagingAreaLayout = styled.div<{ isOpen: boolean }>`
 	position: relative;
-	z-index: 1;
-	display: inline-flex;
+
+	display: flex;
 	flex-direction: column;
-	align-items: center;
+	align-items: flex-start;
 	box-sizing: border-box;
-	width: 44.8rem;
+	width: ${({ isOpen }) => (isOpen ? '44.8rem' : '0')};
+	overflow: hidden;
 
 	background-color: ${({ theme }) => theme.color.Grey.White};
 	border-right: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};
 	border-radius: 0 40px 40px 0;
 
-	animation: ${({ isOpen }) => (isOpen ? slideIn : slideOut)} 0.6s ease forwards;
+	transition: width 0.5s ease-in-out;
 `;
 
 const UpperContainer = styled.div`

--- a/src/components/common/StagingArea/StagingArea.tsx
+++ b/src/components/common/StagingArea/StagingArea.tsx
@@ -51,6 +51,7 @@ const StagingAreaLayout = styled.div<{ isOpen: boolean }>`
 
 	display: flex;
 	flex-direction: column;
+	flex-shrink: 0;
 	align-items: flex-start;
 	box-sizing: border-box;
 	width: ${({ isOpen }) => (isOpen ? '44.8rem' : '0')};

--- a/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
+++ b/src/components/common/StagingArea/StagingAreaTaskContainer.tsx
@@ -75,7 +75,6 @@ function StagingAreaTaskContainer({ handleSelectedTarget, selectedTarget, tasks 
 											}}
 										>
 											<Todo
-												location="staging"
 												key={task.id}
 												status={task.status as StatusType}
 												title={task.name}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -470,8 +470,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 			{isMainModalOpen && selectedTaskId !== null && selectedTimeBlockId !== null && (
 				<MainSettingModal
 					isOpen={isMainModalOpen}
-					top={top}
-					left={left}
 					onClose={closeMainModal}
 					status={selectedStatus}
 					taskId={selectedTaskId}

--- a/src/components/common/v2/dropdown/TimeDropdown.tsx
+++ b/src/components/common/v2/dropdown/TimeDropdown.tsx
@@ -20,11 +20,11 @@ function TimeDropdown({ handleSelectTime, selectedTime }: TimeDropdownProps) {
 		if (selectedTimeRef.current) {
 			selectedTimeRef.current.scrollIntoView({
 				behavior: 'instant',
-				block: 'start',
+				block: 'nearest',
 			});
 
 			if (containerRef.current) {
-				containerRef.current.scrollTop -= 10;
+				containerRef.current.scrollTop += 200;
 			}
 		}
 	}, []);

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -22,8 +22,6 @@ import { getRoundedFormattedCurrTime } from '@/utils/time';
 
 interface MainSettingModalProps {
 	isOpen: boolean;
-	top: number;
-	left: number;
 	taskId: number;
 	onClose: () => void;
 	status: StatusType;
@@ -34,8 +32,6 @@ interface MainSettingModalProps {
 
 function MainSettingModal({
 	isOpen,
-	top,
-	left,
 	taskId,
 	onClose,
 	status,
@@ -208,7 +204,7 @@ function MainSettingModal({
 
 	return (
 		<>
-			<MainSettingModalLayout ref={modalRef} top={top} left={left} onClick={(e) => e.stopPropagation()}>
+			<MainSettingModalLayout ref={modalRef} onClick={(e) => e.stopPropagation()}>
 				<MainSettingModalHeadLayout>
 					<ModalTopButtonBox>
 						<DropdownButton
@@ -262,10 +258,7 @@ function MainSettingModal({
 	);
 }
 
-const MainSettingModalLayout = styled.article<{ top: number; left: number }>`
-	/* position: fixed;
-	top: ${({ top }) => top}px;
-	left: ${({ left }) => left}px; */
+const MainSettingModalLayout = styled.article`
 	position: fixed;
 	top: 50%;
 	left: 50%;

--- a/src/components/common/v2/taskBox/Todo.tsx
+++ b/src/components/common/v2/taskBox/Todo.tsx
@@ -6,14 +6,12 @@ import DropdownButton from '../control/DropdownButton';
 
 import useUpdateTaskStatus from '@/apis/tasks/updateTaskStatus/query';
 import MainSettingModal from '@/components/common/v2/modal/MainSettingModal';
-import MODAL from '@/constants/modalLocation';
 import { STATUS } from '@/types/tasks/taskType';
 import { formatTimeToDueTime } from '@/utils/formatDateTime';
 
 type StatusType = (typeof STATUS)[keyof typeof STATUS];
 
 type TodoProps = {
-	location: 'target' | 'staging';
 	title: string;
 	deadlineDate?: string;
 	deadlineTime?: string;
@@ -26,7 +24,6 @@ type TodoProps = {
 };
 
 function Todo({
-	location,
 	title,
 	deadlineDate,
 	status: initStatus,
@@ -42,9 +39,6 @@ function Todo({
 
 	const [isModalOpen, setModalOpen] = useState(false);
 
-	const [top, setTop] = useState(0);
-	const [left, setLeft] = useState(0);
-
 	useEffect(() => {
 		setStatus(initStatus);
 	}, [initStatus]);
@@ -54,16 +48,7 @@ function Todo({
 			e.preventDefault();
 			return;
 		}
-		const rect = e.currentTarget.getBoundingClientRect();
-		const calculatedTop = rect.top;
-		const adjustedTop = Math.min(calculatedTop, MODAL.SCREEN_HEIGHT - MODAL.TASK_MODAL_HEIGHT);
-		if (location === 'staging') {
-			setTop(adjustedTop);
-			setLeft(rect.width + 20);
-		} else {
-			setTop(adjustedTop);
-			setLeft(rect.right + 12);
-		}
+
 		setModalOpen((prev) => !prev);
 	};
 
@@ -107,8 +92,6 @@ function Todo({
 			</div>
 			<MainSettingModal
 				isOpen={isModalOpen}
-				top={top}
-				left={left}
 				onClose={handleCloseModal}
 				taskId={taskId}
 				status={status}

--- a/src/components/targetArea/FilterSection.tsx
+++ b/src/components/targetArea/FilterSection.tsx
@@ -50,6 +50,7 @@ const IconContainer = styled.div`
 	justify-content: flex-end;
 	box-sizing: border-box;
 	width: 100%;
+	min-width: 45rem;
 	height: 4.8rem;
 	padding: 0.8rem 1.6rem;
 `;

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -67,7 +67,7 @@ const TargetAreaLayout = styled.section`
 	flex-shrink: 0;
 	align-items: flex-start;
 	width: 47.2rem;
-	margin: 0.8rem;
+	margin: 0.8rem 0.7rem;
 
 	background-color: ${({ theme }) => theme.colorToken.Neutral.normal};
 	border: 1px solid ${({ theme }) => theme.palette.Grey.Grey3};

--- a/src/components/targetArea/TargetArea.tsx
+++ b/src/components/targetArea/TargetArea.tsx
@@ -61,6 +61,7 @@ function TargetArea(props: TargetAreaProps) {
 	);
 }
 const TargetAreaLayout = styled.section`
+	z-index: 2;
 	display: flex;
 	flex-direction: column;
 	flex-shrink: 0;

--- a/src/components/targetArea/TargetTaskSection.tsx
+++ b/src/components/targetArea/TargetTaskSection.tsx
@@ -75,7 +75,6 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, target
 									}}
 								>
 									<Todo
-										location="target"
 										key={task.id}
 										title={task.name}
 										deadlineDate={formatDatetoStringKor(task.deadLine?.date)}
@@ -84,12 +83,6 @@ function TargetTaskSection({ handleSelectedTarget, selectedTarget, tasks, target
 										targetDate={targetDate}
 										onClick={() => handleSelectedTarget(task)}
 										status={task.status}
-
-										// handleSelectedTarget={handleSelectedTarget}
-										// selectedTarget={selectedTarget}
-										// isDragging={snapshot.isDragging}
-										// targetDate={targetDate}
-										// dashBoardInprogress={false}
 									/>
 								</TodoSizedWrapper>
 							)}

--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -198,9 +198,9 @@ const TodayLayout = styled.div`
 const CalendarWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
+	flex-grow: 1;
 	align-items: flex-start;
 	box-sizing: border-box;
 	width: fit-content;
-	width: 100%;
 	margin: 1rem 0.8rem 1rem 0;
 `;

--- a/src/stories/Common/Button/Todo.stories.tsx
+++ b/src/stories/Common/Button/Todo.stories.tsx
@@ -27,7 +27,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
 	args: {
-		location: 'target',
 		title: '할 일 제목',
 		deadlineDate: '2024년 12월 31일',
 		deadlineTime: '오후 6시 40분 까지',

--- a/src/stories/modal/MainSettingModal.stories.ts
+++ b/src/stories/modal/MainSettingModal.stories.ts
@@ -18,8 +18,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
 	args: {
 		isOpen: true,
-		top: 10,
-		left: 10,
 		taskId: 1,
 		onClose: () => {},
 		status: '진행중',


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

-  mainSettingModal을 화면의 중앙에 뜨도록 수정했어요.
  - stagingArea에서 열리는 모달의 경우 같은 모달을 호출함에도 뷰포트 기준 가운데에 뜨지 않았는데 해당 문제는 부모인 StagingAreaLayout이 `transform: translateX(-100%); `애니메이션을 적용받으면서 뷰포트가 아니라 StagingAreaLayout을 기준으로 모달이 배치되는 것 때문에 발생하는 문제였어요. 그래서 StagingAreaLayout이 transform을 사용하지 않고 대신 left를 이용하여 애니메이션을 적용하도록 수정했어요.
  `width: ${({ isOpen }) => (isOpen ? '44.8rem' : '0')};`
-  mainSettingModal을 중앙에 뜨도록 수정하면서 기존에 모달 위치 정보를 위해서 필요했던 top, left를 제거했어요.




## 알게된 점 :rocket:

> 기록하며 개발하기!

- StagingAreaLayout에서 모달을 띄우면 가운데에 뜨지만 캘린더에 가려지는 문제가 발생했어요. Target에서는 아무 문제가 없었어서 문제점을 찾아보니 relative는 부모 요소의 z-index를 상속받기 때문에 부모 요소에 높은 z-index가 있으면 그 안에서 relative가 아무리 높아도 효과가 없기 때문이었스빈다. 그래서 `z-index: 1`을 지우면서 해결했어요. 이를 통해서 relative는 부모 요소의 z-index를 상속받는다는 것을 알게되었어용

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex1) 관련 파일은 노션 참고해주세요!
- ex2

## 관련 이슈

close #416

## 스크린샷 (선택)
![Mar-15-2025 02-57-43](https://github.com/user-attachments/assets/7504e134-af24-4ba7-a606-8c6c4bb06db9)
