### PR TITLE
[FIX] 타임블록 관련 QA 수정

### DIFF
--- a/src/apis/timeBlocks/postTimeBlock/query.ts
+++ b/src/apis/timeBlocks/postTimeBlock/query.ts
@@ -9,20 +9,20 @@ const usePostTimeBlock = () => {
 	const queryClient = useQueryClient();
 	const { addToast } = useToast();
 
-	const { mutate, isError } = useMutation({
+	const mutation = useMutation({
 		mutationFn: async ({ taskId, startTime, endTime, isAllTime }: PostTimeBlokType) => {
 			const response = await CreateTimeBlock({ taskId, startTime, endTime, isAllTime });
 			/** response.code가 'conflict'일 때 타임블록 에러 토스트 출력 */
 			if (response && response.code === 'conflict') {
 				addToast(response.message, response.code);
-				throw new Error('error');
+				throw new Error('conflict');
 			}
 			return response;
 		},
 		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['timeblock'] }),
 	});
 
-	return { mutate, isError };
+	return { mutateAsync: mutation.mutateAsync };
 };
 
 export default usePostTimeBlock;

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -23,7 +23,7 @@ const usePatchTimeBlock = () => {
 			const response = await PatchTimeBlock({ taskId, timeBlockId, startTime, endTime, isAllTime });
 			if (response && response.code === 'conflict') {
 				addToast(response.message, response.code);
-				throw new Error('error');
+				throw new Error('conflict');
 			}
 			return response;
 		},
@@ -35,7 +35,7 @@ const usePatchTimeBlock = () => {
 		},
 	});
 
-	return { mutate: mutation.mutate };
+	return { mutateAsync: mutation.mutateAsync };
 };
 
 export default usePatchTimeBlock;

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -268,13 +268,21 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 
 		if (taskId && taskId !== -1) {
 			const startStr = removeTimezone(event.startStr, event.allDay);
-			const endStr = removeTimezone(event.endStr, event.allDay);
+			let endStr = removeTimezone(event.endStr, event.allDay);
+
+			if (info.event.allDay) {
+				endStr = startStr;
+			}
 
 			const prevEvents = [...calendarEvents]; // 기존 상태 저장
 
 			try {
 				setCalendarEvents((prev) =>
-					prev.map((e) => (e.extendedProps.timeBlockId === timeBlockId ? { ...e, start: startStr, end: endStr } : e))
+					prev.map((e) =>
+						e.extendedProps.timeBlockId === timeBlockId
+							? { ...e, start: startStr, end: endStr, allDay: info.event.allDay }
+							: e
+					)
 				);
 
 				await updateMutate({ taskId, timeBlockId, startTime: startStr, endTime: endStr, isAllTime: info.event.allDay });

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -386,7 +386,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 
 			return updatedStatuses;
 		});
-		setFilterPopupOpen(false);
 	};
 
 	// 완료 task 스타일링 위한 클래스명 추가 (주간)

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -134,7 +134,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	const updateRange = (viewType: string, size: string) => {
 		switch (viewType) {
 			case 'dayGridMonth':
-				setRange(30);
+				setRange(42);
 				break;
 			case 'timeGridWeekCustom':
 				setRange(size === 'big' ? 7 : 5);
@@ -158,7 +158,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 			setSelectedTaskId(clickedEvent.extendedProps.taskId);
 			setSelectedTimeBlockId(clickedEvent.extendedProps.timeBlockId);
 			setSelectedStatus(clickedEvent.extendedProps.status);
-			setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr.split('T')[0]));
+			setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr));
 			setMainModalOpen(true);
 		}
 	};
@@ -322,7 +322,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		if (clickedEvent) {
 			setSelectedTaskId(clickedEvent.extendedProps.taskId);
 			setSelectedTimeBlockId(clickedEvent.extendedProps.timeBlockId);
-			setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr.split('T')[0]));
+			setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr));
 			setDeleteModalOpen(true);
 		}
 	};
@@ -370,7 +370,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 			if (clickedEvent) {
 				setSelectedTaskId(Number(info.event.id));
 				setSelectedTimeBlockId(clickedEvent.timeBlockId);
-				setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr.split('T')[0]));
+				setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr));
 				setMainModalOpen(true);
 			}
 		} catch (error) {

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -112,7 +112,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		const newStartDate = new Date(dateInfo.start);
 		const endDate = new Date(dateInfo.end);
 		const centerDate = new Date((newStartDate.getTime() + endDate.getTime()) / 2);
-		const formattedStartDate = newStartDate.toISOString().split('T')[0];
+		const formattedStartDate = newStartDate.toLocaleDateString('sv-SE');
 
 		setCurrentView(dateInfo.view.type);
 		setStartDate(formattedStartDate);
@@ -367,11 +367,10 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 				isAllTime: info.event.allDay,
 			});
 
-			if (clickedEvent) {
+			if (clickedEvent && Object.keys(clickedEvent).length) {
 				setSelectedTaskId(Number(info.event.id));
 				setSelectedTimeBlockId(clickedEvent.timeBlockId);
 				setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr));
-				setMainModalOpen(true);
 			}
 		} catch (error) {
 			console.error('handleEventReceive error:', error);

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -506,6 +506,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					targetDate={selectdTimeBlockDate ? formatDatetoLocalDate(selectdTimeBlockDate) : formatDatetoLocalDate(today)}
 					timeBlockId={selectedTimeBlockId}
 					isAllTime={calendarEvents.find((event) => event.extendedProps.taskId === selectedTaskId)?.allDay || false}
+					isTimeblock={true}
 				/>
 			)}
 		</FullCalendarLayout>

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -473,7 +473,6 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 				)}
 				viewDidMount={handleViewChange}
 				datesSet={handleDatesSet}
-				dateClick={(arg) => handleChangeDate(arg.date)}
 				dayCellContent={(arg) => (
 					<CustomDayCellContent arg={arg} today={today.toDateString()} selectDate={selectDate?.toString()} />
 				)}

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -336,7 +336,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 	};
 
 	// 드래그해서 timeblock 추가
-	const handleEventReceive = (info: EventReceiveArg) => {
+	const handleEventReceive = async (info: EventReceiveArg) => {
 		if (!info.event.start) {
 			throw new Error('Invalid event start time');
 		}
@@ -358,20 +358,25 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 
 		setTop(adjustedTop);
 		setLeft(adjustedLeft);
-		createMutate(
-			{ taskId: Number(info.event.id), startTime: start, endTime: end, isAllTime: info.event.allDay },
-			{
-				onSuccess: () => {
-					if (clickedEvent) {
-						setSelectedTaskId(Number(info.event.id));
-						setSelectedTimeBlockId(clickedEvent.timeBlockId);
-						setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr.split('T')[0]));
-						setMainModalOpen(true);
-					}
-				},
-				onError: () => closeMainModal(),
+
+		try {
+			await createMutate({
+				taskId: Number(info.event.id),
+				startTime: start,
+				endTime: end,
+				isAllTime: info.event.allDay,
+			});
+
+			if (clickedEvent) {
+				setSelectedTaskId(Number(info.event.id));
+				setSelectedTimeBlockId(clickedEvent.timeBlockId);
+				setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr.split('T')[0]));
+				setMainModalOpen(true);
 			}
-		);
+		} catch (error) {
+			console.error('handleEventReceive error:', error);
+			info.event.remove(); // 추가된 이벤트 제거
+		}
 	};
 
 	// CalendarSettingDropdown handler

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -387,6 +387,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 
 			return updatedStatuses;
 		});
+		setFilterPopupOpen(false);
 	};
 
 	// 완료 task 스타일링 위한 클래스명 추가 (주간)
@@ -504,6 +505,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 					right={0.8}
 					selectedStatuses={selectedStatuses}
 					handleStatusChange={handleStatusChange}
+					handleFilterPopup={handleFilterPopup}
 				/>
 			)}
 			{isDeleteModalOpen && selectedTaskId !== null && selectedTimeBlockId !== null && (

--- a/src/components/common/fullCalendar/FullCalendarStyle.ts
+++ b/src/components/common/fullCalendar/FullCalendarStyle.ts
@@ -163,6 +163,10 @@ const FullCalendarLayout = styled.div<{ size: string; currentView: string }>`
 			`}
 	}
 
+	.fc-timegrid .fc-daygrid-body {
+		z-index: 0;
+	}
+
 	.fc-event-allday {
 		height: 2rem;
 	}

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -77,7 +77,7 @@ function Modal({ isOpen, sizeType, top, left, onClose, taskId, targetDate, locat
 
 	const { mutate: deleteMutate } = useDeleteTask();
 	const { mutate: editMutate } = usePatchTaskDescription();
-	const { mutate: createMutate } = usePostTimeBlock();
+	const { mutateAsync: createMutate } = usePostTimeBlock();
 
 	// editMutate({ name, description, deadLine: { date, time } });
 

--- a/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
+++ b/src/components/common/v2/dropdown/CalendarSettingDropdown.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import ModalBackdrop from '@/components/common/modal/ModalBackdrop';
 import CheckButton from '@/components/common/v2/control/CheckButton';
 import { STATUS_OPTIONS, STATUSES } from '@/constants/statuses';
 
@@ -8,6 +9,7 @@ type CalendarSettingDropdownProps = {
 	right?: number;
 	selectedStatuses: (typeof STATUSES)[keyof typeof STATUSES][];
 	handleStatusChange: (status: (typeof STATUSES)[keyof typeof STATUSES]) => void;
+	handleFilterPopup: () => void;
 };
 
 function CalendarSettingDropdown({
@@ -15,19 +17,23 @@ function CalendarSettingDropdown({
 	right = 0,
 	selectedStatuses,
 	handleStatusChange,
+	handleFilterPopup,
 }: CalendarSettingDropdownProps) {
 	return (
-		<CalendarSettingDropdownContainer top={top} right={right}>
-			{STATUS_OPTIONS.map((option) => (
-				<CheckButton
-					key={option.value}
-					label={option.label}
-					onClick={() => handleStatusChange(option.label as (typeof STATUSES)[keyof typeof STATUSES])}
-					size="large"
-					checked={selectedStatuses.includes(option.label as (typeof STATUSES)[keyof typeof STATUSES])}
-				/>
-			))}
-		</CalendarSettingDropdownContainer>
+		<>
+			<CalendarSettingDropdownContainer top={top} right={right}>
+				{STATUS_OPTIONS.map((option) => (
+					<CheckButton
+						key={option.value}
+						label={option.label}
+						onClick={() => handleStatusChange(option.label as (typeof STATUSES)[keyof typeof STATUSES])}
+						size="large"
+						checked={selectedStatuses.includes(option.label as (typeof STATUSES)[keyof typeof STATUSES])}
+					/>
+				))}
+			</CalendarSettingDropdownContainer>
+			<ModalBackdrop onClick={handleFilterPopup} />
+		</>
 	);
 }
 
@@ -35,7 +41,7 @@ const CalendarSettingDropdownContainer = styled.div<{ top: number; right: number
 	position: absolute;
 	top: ${({ top }) => top}rem;
 	right: ${({ right }) => right}rem;
-	z-index: 2;
+	z-index: 4;
 
 	display: flex;
 	flex-direction: column;

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -28,6 +28,7 @@ interface MainSettingModalProps {
 	targetDate: string;
 	timeBlockId?: number;
 	isAllTime?: boolean;
+	isTimeblock?: boolean;
 }
 
 function MainSettingModal({
@@ -38,6 +39,7 @@ function MainSettingModal({
 	targetDate,
 	timeBlockId,
 	isAllTime = false,
+	isTimeblock = false,
 }: MainSettingModalProps) {
 	const { mutate: deleteMutate } = useDeleteTask();
 	const { mutateAsync: editMutate } = usePatchTaskDescription();
@@ -247,7 +249,7 @@ function MainSettingModal({
 					<PopUpTitleBox>
 						<PopUp type="description" defaultValue={descriptionContent} onChange={onDescriptionChange} />
 					</PopUpTitleBox>
-					{isTimeBlockSelected && (
+					{isTimeblock && (
 						<DeadlineBox
 							date={timeBlockDate || new Date(targetDate)}
 							startTime={formatTimeWithAmPm(startTime) || '23:59'}

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -16,7 +16,7 @@ import { useToast } from '@/components/toast/ToastContext';
 import useInput from '@/hooks/useInput';
 import useOutsideClick from '@/hooks/useOutsideClick';
 import { StatusType } from '@/types/tasks/taskType';
-import { formatDatetoLocalDate } from '@/utils/formatDateTime';
+import { formatDatetoLocalDate, formatTimeByAllDay } from '@/utils/formatDateTime';
 import formatTimeWithAmPm from '@/utils/formatTimeWithAmPm';
 import { getRoundedFormattedCurrTime } from '@/utils/time';
 
@@ -190,12 +190,8 @@ function MainSettingModal({
 		}
 
 		try {
-			const formattedStartTime = isAllDay
-				? `${timeBlockDate ? new Date(timeBlockDate).toISOString().split('T')[0] : startTime.split('T')[0]}T00:00`
-				: startTime;
-			const formattedEndTime = isAllDay
-				? `${timeBlockDate ? new Date(timeBlockDate).toISOString().split('T')[0] : endTime.split('T')[0]}T00:00`
-				: endTime;
+			const formattedStartTime = formatTimeByAllDay(startTime, isAllDay, timeBlockDate);
+			const formattedEndTime = formatTimeByAllDay(endTime, isAllDay, timeBlockDate);
 
 			await updateTimeBlockMutate({
 				taskId,

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -61,9 +61,9 @@ const ToastMessage = styled.div<{ code: string }>`
 			case 'success':
 				return theme.colorToken.Primary.normal;
 			case 'error':
-			case 'conflict':
 				return theme.color.Orange.Orange5;
 			case 'info':
+			case 'conflict':
 				return theme.color.Grey.Grey7;
 			default:
 				return theme.colorToken.Primary.normal;

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -61,6 +61,7 @@ const ToastMessage = styled.div<{ code: string }>`
 			case 'success':
 				return theme.colorToken.Primary.normal;
 			case 'error':
+			case 'conflict':
 				return theme.color.Orange.Orange5;
 			case 'info':
 				return theme.color.Grey.Grey7;

--- a/src/stories/Common/dropdown/CalendarSettingDropdown.stories.ts
+++ b/src/stories/Common/dropdown/CalendarSettingDropdown.stories.ts
@@ -21,5 +21,6 @@ export const Default: Story = {
 		right: 0,
 		selectedStatuses: ['미완료', '진행중'],
 		handleStatusChange: () => {},
+		handleFilterPopup: () => {},
 	},
 };

--- a/src/utils/formatDateTime.ts
+++ b/src/utils/formatDateTime.ts
@@ -121,3 +121,15 @@ export const formatDateToLocal = (inputDate: Date): string => {
 	const adjustedDate = new Date(inputDate.getTime() - inputDate.getTimezoneOffset() * 60000);
 	return adjustedDate.toISOString().slice(0, 16);
 };
+
+/**
+ * allDay 이벤트일 경우, timeBlockDate 또는 time 값을 기반으로 날짜만 추출해 T00:00을 붙입니다.
+ * allDay가 아닌 경우 원래 time을 그대로 반환합니다.
+ */
+export const formatTimeByAllDay = (time: string, isAllDay: boolean, timeBlockDate?: Date | null): string => {
+	if (!isAllDay) return time;
+
+	const dateStr = timeBlockDate ? new Date(timeBlockDate).toISOString().split('T')[0] : time.split('T')[0];
+
+	return `${dateStr}T00:00`;
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:


- [x] 타임블록 시간 수정 시 변경이 불가한 위치에 그대로 있는 문제 해결
  - 하루에 같은 테스크를 2번 이상 배치할 경우
  - 이미 타임블록이 존재하는 곳에 테스크를 배치할 경우
  -  모달의 타임블록 수정에서 conflict 발생 시 handleEdit 방지하도록 비동기 처리
- [x] 타임블록을 이동시켜서 수정할 때 종일 칸에 넣으면 새로고침 해야 반영되는 문제 해결
- [x] 타임블록 드래그로 종일에 바로 긁으면 에러 발생하는 문제 해결
- [x] 추가적으로 타임블록 영역의 모달에서만 '진행기간'뜨도록 수정
- [x] conflict 상태일때 토스트의 색상을 기본 파란색에서 error의 색상으로 수정
- [x] 드래그앤 드랍으로 타임블록 시간 수정 변경이 불가한 위치에 그대로 있는 문제 해결 - ~~이거 안되는 거 발견함;;~~

추가적으로 자잘한 qa도 함께 진행했습니다. 
- [x] 모달안의 캘린더 모달이 타임라인 상단에 약간 가려지는 현상 z-index수정
- [x] 캘린더 타임그리드 영역 클릭하면 해당 날짜로 이동하는 로직 제거
- [x] 타임블록 필터 영역 밖을 클릭하면 닫히도록 수정
 
## 알게된 점 :rocket:

> 기록하며 개발하기!

- 기존의 timeblock및 모달의 함수들이 비동기처리가 되어있지 않아서 원하는 대로 동작하지 않던 부분들이 있엇습니다. 
역시 js는 비동기 처리,,,


## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 확인하시고 타임블록 관련한 에러가 아직 남아있다면 말씀 부탁드려요!

## 관련 이슈

close #421

## 스크린샷 (선택)
