### PR TITLE
[FIX] 토스트 undo 기능 있는 경우만 표시

### DIFF
--- a/src/apis/tasks/updateTaskStatus/query.ts
+++ b/src/apis/tasks/updateTaskStatus/query.ts
@@ -54,7 +54,8 @@ const useUpdateTaskStatus = (handleIconMouseLeave: (() => void) | null) => {
 				}
 			};
 
-			addToast('변경사항이 적용되었어요', 'success', revert);
+			const needRevert = updateData.status && updateData.status !== context.originalData.status;
+			addToast('변경사항이 적용되었어요', 'success', needRevert ? revert : undefined);
 
 			// staging과 today중 해당 task가 속한 영역만 쿼리키 무효화
 			const cachedTask = queryClient.getQueryData(QUERY_KEYS.taskDescription(updateData.taskId));

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -38,8 +38,8 @@ function Toast({ message, onClose, code, onRevert }: ToastProps) {
 				{message}
 			</TextLayout>
 			<RevertBox>
-				<RevertText onClick={onRevert}>되돌리기</RevertText>
-				<Icon name="IcnX" />
+				{onRevert && <RevertText onClick={onRevert}>되돌리기</RevertText>}
+				<Icon name="IcnX" onClick={onClose} />
 			</RevertBox>
 		</ToastMessage>
 	);

--- a/src/components/toast/ToastContainer.tsx
+++ b/src/components/toast/ToastContainer.tsx
@@ -4,18 +4,12 @@ import Toast from '@/components/toast/Toast';
 import { useToast } from '@/components/toast/ToastContext';
 
 function ToastContainer() {
-	const { toasts, removeToast, revertToast } = useToast();
+	const { toasts, removeToast } = useToast();
 
 	return (
 		<Container>
-			{toasts.map(({ id, message, code }) => (
-				<Toast
-					key={id}
-					message={message}
-					code={code}
-					onClose={() => removeToast(id)}
-					onRevert={() => revertToast(id)}
-				/>
+			{toasts.map(({ id, message, code, revert }) => (
+				<Toast key={id} message={message} code={code} onClose={() => removeToast(id)} onRevert={revert} />
 			))}
 		</Container>
 	);

--- a/src/components/toast/ToastContext.tsx
+++ b/src/components/toast/ToastContext.tsx
@@ -7,14 +7,13 @@ interface ToastItem {
 	id: number;
 	message: string;
 	code: ToastType;
-	revert: () => void;
+	revert?: () => void;
 }
 
 interface ToastContextProps {
 	toasts: ToastItem[];
 	addToast: (message: string, code: ToastType, revert?: () => void) => void;
 	removeToast: (id: number) => void;
-	revertToast: (id: number) => void;
 }
 
 const ToastContext = createContext<ToastContextProps | null>(null);
@@ -32,16 +31,11 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 
 	const addToast = (message: string, code: ToastType, revert?: () => void) => {
 		const id = new Date().getTime();
-		setToasts((prevToasts) => [...prevToasts, { id, message, code, revert: revert ?? (() => {}) }]);
+		setToasts((prevToasts) => [...prevToasts, { id, message, code, revert }]);
 	};
 
 	const removeToast = (id: number) => {
 		setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
-	};
-
-	const revertToast = (id: number) => {
-		const toast = toasts.find((t) => t.id === id);
-		toast?.revert();
 	};
 
 	const value = useMemo(
@@ -49,7 +43,6 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 			toasts,
 			addToast,
 			removeToast,
-			revertToast,
 		}),
 		[toasts]
 	);


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- revert 함수를 addToast 에 넣은 경우만 표시하도록 수정했습니다.
- 불필요한 함수 정리했습니다
```ts
const needRevert = updateData.status && updateData.status !== context.originalData.status;
```
updateData.status 가 있으며 이전과 같지 않은 경우에만 revert를 활성화합니다.
staging -> today, today-> staging 과 같이 움직이는 부분에도 status 업데이트 하는 콜이 null 을 넣어서 호출되고 있어서 일단 이렇게 적용했습니다.  
근데 모달에서 수정할 때 status 바꾸는 거랑 내용 바꾸는 거 api 를 따로 써서 status 를 바꾸면 되돌리기 텍스트가 무조건 뜹니다

## 알게된 점 :rocket:

> 기록하며 개발하기!

-

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 볼륨이 크다고 생각해 일단 이슈 닫기로 이야기되었었는데, 이부분 삭제 태스크 원복, 타임블럭 등 undo 어떻게 하면 좋을지 아이디어 있으시면 자유롭게 공유해주시면 감사하겟습니다.

## 관련 이슈

close #420

## 스크린샷 (선택)
