### PR TITLE
[REFACTOR] 모달 포지셔닝 & 오픈로직 변경

### DIFF
--- a/src/components/common/datePicker/DateCorrectionModal.tsx
+++ b/src/components/common/datePicker/DateCorrectionModal.tsx
@@ -18,12 +18,21 @@ interface DateCorrectionModalProps {
 	top?: number;
 	left?: number;
 	right?: number;
+	isTopCenter?: boolean;
 	date: string | null;
 	onClick: () => void;
 	handleCurrentDate?: (newDate: Date) => void;
 }
 
-function DateCorrectionModal({ top = 0, left, right, date, onClick, handleCurrentDate }: DateCorrectionModalProps) {
+function DateCorrectionModal({
+	top = 0,
+	left,
+	right,
+	isTopCenter = false,
+	date,
+	onClick,
+	handleCurrentDate,
+}: DateCorrectionModalProps) {
 	const prevDate = date ? new Date(date) : null;
 	const [currentDate, setCurrentDate] = useState<Date | null>(prevDate);
 	const [isOutOfBounds, setIsOutOfBounds] = useState(false);
@@ -76,6 +85,7 @@ function DateCorrectionModal({ top = 0, left, right, date, onClick, handleCurren
 				top={top}
 				left={left}
 				right={right}
+				isTopCenter={isTopCenter}
 				isOutOfBounds={isOutOfBounds}
 				onClick={(e) => e.stopPropagation()}
 			>
@@ -101,12 +111,19 @@ const DateCorrectionModalLayout = styled.div<{
 	top: number;
 	left?: number;
 	right?: number;
+	isTopCenter: boolean;
 	isOutOfBounds: boolean;
 }>`
 	position: absolute;
-	top: ${({ isOutOfBounds, top }) => (isOutOfBounds ? 'unset' : `${top}rem`)};
+	top: ${({ isTopCenter, isOutOfBounds, top }) => {
+		if (isTopCenter) return '50%';
+		if (isOutOfBounds) return 'unset';
+		return `${top}rem`;
+	}};
 	bottom: ${({ isOutOfBounds }) => (isOutOfBounds ? '0rem' : 'unset')};
 	z-index: 4;
+
+	transform: ${({ isTopCenter }) => (isTopCenter ? 'translateY(-50%)' : 'none')};
 
 	${({ left, right }) => {
 		if (left !== undefined) {

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -144,23 +144,25 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 		}
 	};
 
+	let lastClickTime = 0;
+
 	const handleEventClick = (info: EventClickArg) => {
-		const rect = info.el.getBoundingClientRect();
-		const calculatedTop = rect.top;
-		const screenHeight = window.innerHeight;
-		const adjustedTop = Math.min(calculatedTop, screenHeight - MODAL.TASK_MODAL_HEIGHT);
-		setTop(adjustedTop);
-		setLeft(rect.left - MODAL.TASK_MODAL_WIDTH - 50);
+		const now = Date.now();
 
-		const clickedEvent = info.event;
+		// 0.3초 내에 클릭 시 더블클릭으로 간주
+		if (now - lastClickTime < 300) {
+			const clickedEvent = info.event;
 
-		if (clickedEvent) {
-			setSelectedTaskId(clickedEvent.extendedProps.taskId);
-			setSelectedTimeBlockId(clickedEvent.extendedProps.timeBlockId);
-			setSelectedStatus(clickedEvent.extendedProps.status);
-			setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr));
-			setMainModalOpen(true);
+			if (clickedEvent) {
+				setSelectedTaskId(clickedEvent.extendedProps.taskId);
+				setSelectedTimeBlockId(clickedEvent.extendedProps.timeBlockId);
+				setSelectedStatus(clickedEvent.extendedProps.status);
+				setSelectdTimeBlockDate(removeTimezone(clickedEvent.startStr));
+				setMainModalOpen(true);
+			}
 		}
+
+		lastClickTime = now;
 	};
 
 	const closeDeleteModal = () => {

--- a/src/components/common/modal/ModalBackdrop.tsx
+++ b/src/components/common/modal/ModalBackdrop.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-const ModalBackdrop = styled.div`
+const ModalBackdropStyle = styled.div<{ isBackgroundColor: boolean }>`
 	position: fixed;
 	top: 0;
 	right: 0;
@@ -9,8 +9,17 @@ const ModalBackdrop = styled.div`
 	width: 100vw;
 	height: 100vh;
 
-	background-color: ${({ theme }) => theme.color.Grey.Grey8};
-	opacity: 0.2;
+	background-color: ${({ theme, isBackgroundColor }) => (isBackgroundColor ? theme.color.Grey.Grey8 : 'transparent')};
+	opacity: ${({ isBackgroundColor }) => (isBackgroundColor ? 0.2 : 0)};
 `;
+
+interface ModalBackdropProps {
+	isBackgroundColor?: boolean;
+	onClick: () => void;
+}
+
+function ModalBackdrop({ isBackgroundColor = false, onClick }: ModalBackdropProps) {
+	return <ModalBackdropStyle isBackgroundColor={isBackgroundColor} onClick={onClick} />;
+}
 
 export default ModalBackdrop;

--- a/src/components/common/modal/ModalBackdrop.tsx
+++ b/src/components/common/modal/ModalBackdrop.tsx
@@ -8,6 +8,9 @@ const ModalBackdrop = styled.div`
 	z-index: 3;
 	width: 100vw;
 	height: 100vh;
+
+	background-color: ${({ theme }) => theme.color.Grey.Grey8};
+	opacity: 0.2;
 `;
 
 export default ModalBackdrop;

--- a/src/components/common/modal/ModalBackdrop.tsx
+++ b/src/components/common/modal/ModalBackdrop.tsx
@@ -15,11 +15,16 @@ const ModalBackdropStyle = styled.div<{ isBackgroundColor: boolean }>`
 
 interface ModalBackdropProps {
 	isBackgroundColor?: boolean;
-	onClick: () => void;
+	onClick: React.MouseEventHandler<HTMLElement>;
+	children?: React.ReactNode;
 }
 
-function ModalBackdrop({ isBackgroundColor = false, onClick }: ModalBackdropProps) {
-	return <ModalBackdropStyle isBackgroundColor={isBackgroundColor} onClick={onClick} />;
+function ModalBackdrop({ isBackgroundColor = false, onClick, children }: ModalBackdropProps) {
+	return (
+		<ModalBackdropStyle isBackgroundColor={isBackgroundColor} onClick={onClick}>
+			{children}
+		</ModalBackdropStyle>
+	);
 }
 
 export default ModalBackdrop;

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -265,7 +265,7 @@ function MainSettingModal({
 					<Button type="solid" size="medium" label="확인" onClick={handleConfirm} />
 				</MainSettingModalButtonLayout>
 			</MainSettingModalLayout>
-			<ModalBackdrop onClick={onClose} />
+			<ModalBackdrop isBackgroundColor onClick={onClose} />
 		</>
 	);
 }

--- a/src/components/common/v2/popup/DateBtn.tsx
+++ b/src/components/common/v2/popup/DateBtn.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import DateCorrectionModal from '@/components/common/datePicker/DateCorrectionModal';
 import Icon from '@/components/common/Icon';
@@ -16,6 +16,14 @@ interface DateBtnProps {
 
 function DateBtn({ isAllday, isEditMode, startTime, endTime, date, handleDate }: DateBtnProps) {
 	const [isOpen, setIsOpen] = useState(false);
+	const [btnWidth, setBtnWidth] = useState<number>(0);
+	const btnRef = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		if (btnRef.current) {
+			setBtnWidth(btnRef.current.offsetWidth);
+		}
+	}, [isOpen]);
 
 	const renderTimeText = () => {
 		if (isAllday) return null;
@@ -49,7 +57,7 @@ function DateBtn({ isAllday, isEditMode, startTime, endTime, date, handleDate }:
 
 	return (
 		<DateWrapper onBlur={handleBlur} tabIndex={-1}>
-			<DateBtnLayout onClick={onClickDateBtn} isActive={isOpen}>
+			<DateBtnLayout onClick={onClickDateBtn} isActive={isOpen} ref={btnRef}>
 				<Icon name={isEditMode ? 'IcnCalendar' : 'IcnModify'} size="tiny" color="nomal" />
 				<TextBox>
 					{formatDateWithDay(date)} {!isEditMode && renderTimeText()}
@@ -61,7 +69,8 @@ function DateBtn({ isAllday, isEditMode, startTime, endTime, date, handleDate }:
 						date={formatDateWithDay(date)}
 						onClick={handleModalClose}
 						handleCurrentDate={handleCurrentDate}
-						top={0.8}
+						isTopCenter
+						left={(btnWidth + 8) / 10}
 					/>
 				</DropdownStyle>
 			)}

--- a/src/components/common/v2/popup/DateBtn.tsx
+++ b/src/components/common/v2/popup/DateBtn.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import DateCorrectionModal from '@/components/common/datePicker/DateCorrectionModal';
 import Icon from '@/components/common/Icon';
@@ -16,14 +16,7 @@ interface DateBtnProps {
 
 function DateBtn({ isAllday, isEditMode, startTime, endTime, date, handleDate }: DateBtnProps) {
 	const [isOpen, setIsOpen] = useState(false);
-	const [btnWidth, setBtnWidth] = useState<number>(0);
 	const btnRef = useRef<HTMLButtonElement>(null);
-
-	useEffect(() => {
-		if (btnRef.current) {
-			setBtnWidth(btnRef.current.offsetWidth);
-		}
-	}, [isOpen]);
 
 	const renderTimeText = () => {
 		if (isAllday) return null;
@@ -70,7 +63,7 @@ function DateBtn({ isAllday, isEditMode, startTime, endTime, date, handleDate }:
 						onClick={handleModalClose}
 						handleCurrentDate={handleCurrentDate}
 						isTopCenter
-						left={(btnWidth + 8) / 10}
+						left={19.2}
 					/>
 				</DropdownStyle>
 			)}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- **백드롭 색상을 추가 후, `MainSettingModal`에만 적용하였습니다.** 
  - `isBackgroundColor` props를 옵셔널로 두어, 해당 props 추가 시 색상 적용됩니다.
- **메인모달 내부 모달(캘린더) 포지셔닝 (스크린샷 참고해주세요)**
- **모달 오픈 로직 전부 더블클릭으로 통일**
  - 타임블록은 fullcalendar라이브러리의 event라서, `onDoubleClick`을 적용하지 못해서 '0.3초 내에 또다시 클릭 시 더블클릭으로 간주'하여 반영했습니다.

## 알게된 점 :rocket:

> 기록하며 개발하기!

- 풀캘린더 이벤트에 더블클릭을 달 순 있지만, fullcalendar에서 eventDoubleClick 등의 이벤트를 지원하지 않는 관계로 직접적인 dom조작으로 만 접근이 가능합니다. 0.3초 내에 다시한번 클릭 시 더블클릭으로 간주하도록 진행해도 충분히 자연스러움 & 이벤트 꼬이지 않게 접근 가능하네요

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


## 관련 이슈

close #419 

## 스크린샷 (선택)

메인모달 내부의 캘린더모달 위치입니다.
<p float="left">
  <img src="https://github.com/user-attachments/assets/d15e129f-14d0-400c-bb4e-b05dc0e74ece" width="45%" />
  <img src="https://github.com/user-attachments/assets/05cf8dd2-0be9-4960-a950-bd201d443aaa" width="45%" />
</p>

