### PR TITLE
[FIX] 캘린더 today 영역 오늘 버튼 연동 끊기

### DIFF
--- a/src/pages/Today.tsx
+++ b/src/pages/Today.tsx
@@ -23,7 +23,8 @@ function Today() {
 	const [stagingSortOrder, setStagingSortOrder] = useState<SortOrderType>(storedStagingSortOrder || 'CUSTOM_ORDER');
 	const [targetSortOrder, setTargetSortOrder] = useState<SortOrderType>(storedTargetSortOrder || 'CUSTOM_ORDER');
 
-	const [selectedDate, setTargetDate] = useState(new Date());
+	const [selectedDate, setSelectedDate] = useState(new Date());
+	const [calenderSelectedDate, setCalenderSelectedDate] = useState(new Date());
 	const targetDate = formatDatetoLocalDate(selectedDate);
 	const [isDumpAreaOpen, setDumpAreaOpen] = useState(true);
 
@@ -53,21 +54,24 @@ function Today() {
 	const handlePrevBtn = () => {
 		const newDate = new Date(selectedDate);
 		newDate.setDate(newDate.getDate() - 1);
-		setTargetDate(newDate);
+		setSelectedDate(newDate);
 	};
 
 	const handleNextBtn = () => {
 		const newDate = new Date(selectedDate);
 		newDate.setDate(newDate.getDate() + 1);
-		setTargetDate(newDate);
+		setSelectedDate(newDate);
 	};
 
 	const handleTodayBtn = () => {
-		setTargetDate(new Date());
+		setSelectedDate(new Date());
 	};
 
 	const handleChangeDate = (target: Date) => {
-		setTargetDate(target);
+		setSelectedDate(target);
+	};
+	const handleChangeCalenderDate = (target: Date) => {
+		setCalenderSelectedDate(target);
 	};
 
 	const handleDragEnd = (result: DropResult) => {
@@ -179,8 +183,8 @@ function Today() {
 				<FullCalendarBox
 					size={isDumpAreaOpen ? 'small' : 'big'}
 					selectedTarget={selectedTarget}
-					selectDate={selectedDate}
-					handleChangeDate={handleChangeDate}
+					selectDate={calenderSelectedDate}
+					handleChangeDate={handleChangeCalenderDate}
 				/>
 			</CalendarWrapper>
 		</TodayLayout>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- today 영역과 캘린더 영역 `selectedDate` 연동을 끊었습니다
- 전역상태 안넣었고 단순하게 `selectedDate`, `calenderSelectedDate` 으로 선택된 날짜 state 를 분리했습니다.
- 노션에는 오늘버튼 연동 끊기라고 되어있는데.. 날짜 이동하는 것도 끊어야 하는 것 맞죠?? 일단 끊어두었습니다.

selectedDate와 선택된 태스크 정보는 전체적으로 사용되는 것 같아 전역상태관리 넣어도 될 것 같아요..
따로 이슈파서 정리하면 좋을듯


## 관련 이슈

close #426

## 스크린샷 (선택)
![Mar-26-2025 20-28-04](https://github.com/user-attachments/assets/043e6d6d-095c-4063-b44d-4604ce955aee)

