### PR TITLE
[FIX] 캘린더 모달 오늘 버튼 동작 정상화

### DIFF
--- a/src/components/common/datePicker/CorrectionCustomHeader.tsx
+++ b/src/components/common/datePicker/CorrectionCustomHeader.tsx
@@ -9,6 +9,8 @@ interface CustomHeaderProps {
 	date: Date;
 	decreaseMonth: () => void;
 	increaseMonth: () => void;
+	changeMonth: (month: number) => void;
+	changeYear: (year: number) => void;
 	prevMonthButtonDisabled: boolean;
 	nextMonthButtonDisabled: boolean;
 	onChange: (date: Date | null) => void;
@@ -19,6 +21,8 @@ function CorrectionCustomHeader({
 	date,
 	decreaseMonth,
 	increaseMonth,
+	changeMonth,
+	changeYear,
 	prevMonthButtonDisabled,
 	nextMonthButtonDisabled,
 	onChange,
@@ -34,6 +38,13 @@ function CorrectionCustomHeader({
 	const IconButtonColorCss = css`
 		color: ${color.Grey.Grey4};
 	`;
+
+	const changeDateToToday = () => {
+		onChange(today);
+		changeYear(today.getUTCFullYear());
+		changeMonth(today.getUTCMonth());
+	};
+
 	return (
 		<HeaderLayout className="react-datepicker__header-custom">
 			<IconButton
@@ -55,7 +66,7 @@ function CorrectionCustomHeader({
 						label="오늘"
 						size="medium"
 						type="outlined-assistive"
-						onClick={() => onChange(today)}
+						onClick={changeDateToToday}
 						additionalCss={ButtonColorCss}
 					/>
 					<IconButton

--- a/src/components/common/fullCalendar/FullCalendarBox.tsx
+++ b/src/components/common/fullCalendar/FullCalendarBox.tsx
@@ -492,7 +492,7 @@ function FullCalendarBox({ size, selectDate, selectedTarget, handleChangeDate }:
 			/>
 			{isCalendarPopupOpen && (
 				<DateCorrectionModal
-					date={new Date().toISOString()}
+					date={startDate}
 					onClick={handleCalendarPopup}
 					top={9.8}
 					right={0.8}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- DateCorrectionModal 오늘 버튼 동작 정상화

## 알게된 점 :rocket:

> 기록하며 개발하기!

- fullcalender의 `ReactDatePickerCustomHeaderProps`에 change Month, Year 함수 통해 현재 보고있는 달력 뷰 조정 가능

## 리뷰 요구사항 :speech_balloon:

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- fullcalendar에서 오늘 기능은 없어도 뷰 조정 함수를 지원해줘서 저번 의논보다 굉장히 간단하게 끝났습니다~

## 관련 이슈

close #428 

## 스크린샷 (선택)
