### PR TITLE
[FIX] 기존 toast의 타입 conflict에서 info로 수정

### DIFF
--- a/src/apis/timeBlocks/postTimeBlock/query.ts
+++ b/src/apis/timeBlocks/postTimeBlock/query.ts
@@ -12,10 +12,10 @@ const usePostTimeBlock = () => {
 	const mutation = useMutation({
 		mutationFn: async ({ taskId, startTime, endTime, isAllTime }: PostTimeBlokType) => {
 			const response = await CreateTimeBlock({ taskId, startTime, endTime, isAllTime });
-			/** response.code가 'conflict'일 때 타임블록 에러 토스트 출력 */
-			if (response && response.code === 'conflict') {
+			/** response.code가 'info'일 때 타임블록 에러 토스트 출력 */
+			if (response && response.code === 'info') {
 				addToast(response.message, response.code);
-				throw new Error('conflict');
+				throw new Error('info');
 			}
 			return response;
 		},

--- a/src/apis/timeBlocks/updateTimeBlock/query.ts
+++ b/src/apis/timeBlocks/updateTimeBlock/query.ts
@@ -21,9 +21,9 @@ const usePatchTimeBlock = () => {
 			}
 
 			const response = await PatchTimeBlock({ taskId, timeBlockId, startTime, endTime, isAllTime });
-			if (response && response.code === 'conflict') {
+			if (response && response.code === 'info') {
 				addToast(response.message, response.code);
-				throw new Error('conflict');
+				throw new Error('info');
 			}
 			return response;
 		},

--- a/src/components/common/v2/modal/MainSettingModal.tsx
+++ b/src/components/common/v2/modal/MainSettingModal.tsx
@@ -140,7 +140,7 @@ function MainSettingModal({
 		} catch (error) {
 			console.error('handleConfirm error:', error);
 
-			if (error === 'conflict') {
+			if (error === 'info') {
 				return; // handleTimeBlockUpdate conflict나면 종료
 			}
 		} finally {
@@ -202,7 +202,7 @@ function MainSettingModal({
 			});
 		} catch (error) {
 			console.error('handleTimeBlockUpdate error:', error);
-			throw new Error('conflict');
+			throw new Error('info');
 		}
 	};
 

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -11,7 +11,7 @@ const toastIcon: Record<ToastType, { icon: JSX.Element }> = {
 	error: {
 		icon: <Icon name="IcnDelete" />,
 	},
-	conflict: {
+	info: {
 		icon: <Icon name="IcnAlert" />,
 	},
 };
@@ -63,7 +63,6 @@ const ToastMessage = styled.div<{ code: string }>`
 			case 'error':
 				return theme.color.Orange.Orange5;
 			case 'info':
-			case 'conflict':
 				return theme.color.Grey.Grey7;
 			default:
 				return theme.colorToken.Primary.normal;

--- a/src/types/toastType.ts
+++ b/src/types/toastType.ts
@@ -1,1 +1,1 @@
-export type ToastType = 'success' | 'error' | 'conflict';
+export type ToastType = 'success' | 'error' | 'info';


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 작업 내용 :technologist:

- 기존 타임블록 충돌관련한 toast의 타입을 `conflict`에서 `info`로 수정하였습니다.


## 관련 이슈

close #432

## 스크린샷 (선택)
<img width="540" alt="image" src="https://github.com/user-attachments/assets/96601cc1-30b0-4fe9-b882-c2f3d6559930" />
